### PR TITLE
Minor code cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ final TableScanNode scanNode = new TableScanNode(
         "connector-hive",
         "table-1",
         false,
-        Collections.emptyList(),
+        List.of(),
         null,
         outputType,
-        Collections.emptyMap()
+        Map.of()
     ),
     toAssignments(outputType)
 );

--- a/src/main/java/io/github/zhztheplayer/velox4j/aggregate/AggregateStep.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/aggregate/AggregateStep.java
@@ -11,7 +11,6 @@ public enum AggregateStep {
 
   private final String value;
 
-  @JsonCreator
   AggregateStep(String value) {
     this.value = value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/ColumnType.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/ColumnType.java
@@ -11,7 +11,6 @@ public enum ColumnType {
 
   private final String value;
 
-  @JsonCreator
   ColumnType(String value) {
     this.value = value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/FileFormat.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/FileFormat.java
@@ -18,7 +18,6 @@ public enum FileFormat {
 
   private final String value;
 
-  @JsonCreator
   FileFormat(String value) {
     this.value = value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/AggregationNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/AggregationNode.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
-import io.github.zhztheplayer.velox4j.type.Type;
 
 import java.util.List;
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -23,12 +23,10 @@ import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
-import io.github.zhztheplayer.velox4j.resource.Resources;
-import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
-import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
 import io.github.zhztheplayer.velox4j.test.TpchTests;
+import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.Type;
@@ -38,7 +36,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -183,10 +180,10 @@ public class QueryTest {
             "connector-hive",
             "tab-1",
             false,
-            Collections.emptyList(),
+            List.of(),
             null,
             outputType,
-            Collections.emptyMap()
+            Map.of()
         ),
         toAssignments(outputType)
     );


### PR DESCRIPTION
`@JsonCreator` is not needed for enum deserialization. Remove the annotation usages.

References:

https://github.com/FasterXML/jackson-databind/blob/2.19/src/main/java/com/fasterxml/jackson/databind/deser/std/EnumDeserializer.java

https://github.com/FasterXML/jackson-databind/blob/2.19/src/main/java/com/fasterxml/jackson/databind/util/EnumResolver.java