### PR TITLE
Add ProjectNode

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
@@ -1,0 +1,39 @@
+package io.github.zhztheplayer.velox4j.plan;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.zhztheplayer.velox4j.expression.TypedExpr;
+
+import java.util.List;
+
+public class ProjectNode extends PlanNode {
+  private final List<PlanNode> sources;
+  private final List<String> names;
+  private final List<TypedExpr> projections;
+
+  public ProjectNode(
+      @JsonProperty("id") String id,
+      @JsonProperty("sources") List<PlanNode> sources,
+      @JsonProperty("names") List<String> names,
+      @JsonProperty("projections") List<TypedExpr> projections) {
+    super(id);
+    this.sources = sources;
+    this.names = names;
+    this.projections = projections;
+  }
+
+  @Override
+  protected List<PlanNode> getSources() {
+    return sources;
+  }
+
+  @JsonGetter("names")
+  public List<String> names() {
+    return names;
+  }
+
+  @JsonGetter("projections")
+  public List<TypedExpr> projections() {
+    return projections;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -17,6 +17,7 @@ import io.github.zhztheplayer.velox4j.expression.InputTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.LambdaTypedExpr;
 import io.github.zhztheplayer.velox4j.filter.AlwaysTrue;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
+import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
 import io.github.zhztheplayer.velox4j.query.Query;
@@ -124,6 +125,7 @@ public final class VeloxSerializables {
     NAME_REGISTRY.registerClass("ValuesNode", ValuesNode.class);
     NAME_REGISTRY.registerClass("TableScanNode", TableScanNode.class);
     NAME_REGISTRY.registerClass("AggregationNode", AggregationNode.class);
+    NAME_REGISTRY.registerClass("ProjectNode", ProjectNode.class);
   }
 
   private static void retisterConfig() {

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -9,6 +9,7 @@ import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.PlanNode;
+import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
 import io.github.zhztheplayer.velox4j.sort.SortOrder;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
@@ -81,5 +82,14 @@ public class PlanNodeSerdeTest {
         List.of(0)
     );
     SerdeTests.testVeloxSerializableRoundTrip(aggregationNode);
+  }
+
+  @Test
+  public void testProjectNode() {
+    final PlanNode scan = SerdeTests.newSampleTableScanNode();
+    final ProjectNode projectNode = new ProjectNode("id-1", List.of(scan),
+        List.of("foo"),
+        List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")));
+    SerdeTests.testVeloxSerializableRoundTrip(projectNode);
   }
 }

--- a/src/test/resources/query-output/tpch-nation-project-1.tsv
+++ b/src/test/resources/query-output/tpch-nation-project-1.tsv
@@ -1,0 +1,26 @@
+n_nationkey	n_comment
+0	haggle. carefully final deposits detect slyly agai
+1	al foxes promise slyly according to the regular accounts. bold requests alon
+2	y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special
+3	eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
+4	y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
+5	ven packages wake quickly. regu
+6	refully final requests. regular, ironi
+7	l platelets. regular accounts x-ray: unusual, regular acco
+8	ss excuses cajole slyly across the packages. deposits print aroun
+9	slyly express asymptotes. regular deposits haggle slyly. carefully ironic hockey players sleep blithely. carefull
+10	efully alongside of the slyly final dependencies.
+11	nic deposits boost atop the quickly final requests? quickly regula
+12	ously. final, express gifts cajole a
+13	ic deposits are blithely about the carefully regular pa
+14	pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t
+15	rns. blithely bold courts among the closely regular packages use furiously bold platelets?
+16	s. ironic, unusual asymptotes wake blithely r
+17	platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun
+18	c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos
+19	ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account
+20	ts. silent requests haggle. closely express packages sleep across the blithely
+21	hely enticingly express accounts. even, final
+22	requests against the platelets use never according to the quickly regular pint
+23	eans boost carefully special requests. accounts are. carefull
+24	y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be


### PR DESCRIPTION
*(Note: The PR is at the same time an example of contribution)*

The PR adds `ProjectNode` that was already supported by velox to velox4j. 

See the code references of `ProjectNode` in velox:

1. [Class declaration of `ProjectNode`](https://github.com/facebookincubator/velox/blob/99f819bff740004dc641ef216725287cc2e46f64/velox/core/PlanNode.h#L459-L532)
2. [Serde code of `ProjectNode`](https://github.com/facebookincubator/velox/blob/99f819bff740004dc641ef216725287cc2e46f64/velox/core/PlanNode.cpp#L967-L986)

In this PR, we add the following parts of code to make sure `ProjectNode` is supported in velox4j and is well tested:

1. The base definition of `ProjectNode` in velox4j: [link](https://github.com/zhztheplayer/velox4j/blob/eb6533f9caebf6f0c0d7c0220cb54b4e45ad9857/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java)
2. Serde registration of `ProjectNode` in velox4j: [link](https://github.com/zhztheplayer/velox4j/blob/eb6533f9caebf6f0c0d7c0220cb54b4e45ad9857/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java#L128)
3. Serde test code: [link](https://github.com/zhztheplayer/velox4j/blob/eb6533f9caebf6f0c0d7c0220cb54b4e45ad9857/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java#L87-L94)
4. Query test
   - Test code: [link](https://github.com/zhztheplayer/velox4j/blob/eb6533f9caebf6f0c0d7c0220cb54b4e45ad9857/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java#L141-L163)
   - Expected query output: [link](https://github.com/zhztheplayer/velox4j/blob/eb6533f9caebf6f0c0d7c0220cb54b4e45ad9857/src/test/resources/query-output/tpch-nation-project-1.tsv)