### PR TITLE
Add FilterNode

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
@@ -1,0 +1,31 @@
+package io.github.zhztheplayer.velox4j.plan;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.zhztheplayer.velox4j.expression.TypedExpr;
+
+import java.util.List;
+
+public class FilterNode extends PlanNode {
+  private final List<PlanNode> sources;
+  private final TypedExpr filter;
+
+  public FilterNode(
+      @JsonProperty("id") String id,
+      @JsonProperty("sources") List<PlanNode> sources,
+      @JsonProperty("filter") TypedExpr filter) {
+    super(id);
+    this.sources = sources;
+    this.filter = filter;
+  }
+
+  @Override
+  protected List<PlanNode> getSources() {
+    return sources;
+  }
+
+  @JsonGetter("filter")
+  public TypedExpr getFilter() {
+    return filter;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
@@ -1,5 +1,6 @@
 package io.github.zhztheplayer.velox4j.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
@@ -10,6 +11,7 @@ public class FilterNode extends PlanNode {
   private final List<PlanNode> sources;
   private final TypedExpr filter;
 
+  @JsonCreator
   public FilterNode(
       @JsonProperty("id") String id,
       @JsonProperty("sources") List<PlanNode> sources,

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
@@ -1,5 +1,6 @@
 package io.github.zhztheplayer.velox4j.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
@@ -11,6 +12,7 @@ public class ProjectNode extends PlanNode {
   private final List<String> names;
   private final List<TypedExpr> projections;
 
+  @JsonCreator
   public ProjectNode(
       @JsonProperty("id") String id,
       @JsonProperty("sources") List<PlanNode> sources,

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -17,6 +17,7 @@ import io.github.zhztheplayer.velox4j.expression.InputTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.LambdaTypedExpr;
 import io.github.zhztheplayer.velox4j.filter.AlwaysTrue;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
+import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
@@ -126,6 +127,7 @@ public final class VeloxSerializables {
     NAME_REGISTRY.registerClass("TableScanNode", TableScanNode.class);
     NAME_REGISTRY.registerClass("AggregationNode", AggregationNode.class);
     NAME_REGISTRY.registerClass("ProjectNode", ProjectNode.class);
+    NAME_REGISTRY.registerClass("FilterNode", FilterNode.class);
   }
 
   private static void retisterConfig() {

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -15,6 +15,7 @@ import io.github.zhztheplayer.velox4j.connector.HiveColumnHandle;
 import io.github.zhztheplayer.velox4j.connector.HiveConnectorSplit;
 import io.github.zhztheplayer.velox4j.connector.HiveTableHandle;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
+import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.iterator.DownIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
@@ -22,6 +23,7 @@ import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
+import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
@@ -29,9 +31,12 @@ import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
 import io.github.zhztheplayer.velox4j.test.TpchTests;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
+import io.github.zhztheplayer.velox4j.type.BooleanType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.Type;
 import io.github.zhztheplayer.velox4j.type.VarCharType;
+import io.github.zhztheplayer.velox4j.variant.BigIntValue;
+import io.github.zhztheplayer.velox4j.variant.BooleanValue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -158,6 +163,29 @@ public class QueryTest {
     UpIteratorTests.assertIterator(itr)
         .assertNumRowVectors(1)
         .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-nation-project-1.tsv"))
+        .run();
+    jniApi.close();
+  }
+
+  @Test
+  public void testFilter() {
+    final JniApi jniApi = JniApi.create(memoryManager);
+    final File file = TpchTests.Table.NATION.file();
+    final RowType outputType = TpchTests.Table.NATION.schema();
+    final TableScanNode scanNode = newSampleScanNode(outputType);
+    final List<BoundSplit> splits = List.of(
+        newSampleSplit(scanNode, file)
+    );
+    final FilterNode filterNode = new FilterNode("id-12", List.of(scanNode),
+        new CallTypedExpr(new BooleanType(), List.of(
+            FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey"),
+            ConstantTypedExpr.create(jniApi, new BigIntValue(3))),
+            "greaterthanorequal"));
+    final Query query = new Query(filterNode, splits, Config.empty(), ConnectorConfig.empty());
+    final UpIterator itr = query.execute(jniApi);
+    UpIteratorTests.assertIterator(itr)
+        .assertNumRowVectors(1)
+        .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-nation-filter-1.tsv"))
         .run();
     jniApi.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -176,7 +176,7 @@ public class QueryTest {
     final List<BoundSplit> splits = List.of(
         newSampleSplit(scanNode, file)
     );
-    final FilterNode filterNode = new FilterNode("id-12", List.of(scanNode),
+    final FilterNode filterNode = new FilterNode("id-2", List.of(scanNode),
         new CallTypedExpr(new BooleanType(), List.of(
             FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey"),
             ConstantTypedExpr.create(jniApi, new BigIntValue(3))),

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -3,16 +3,19 @@ package io.github.zhztheplayer.velox4j.serde;
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
+import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
+import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.PlanNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
 import io.github.zhztheplayer.velox4j.sort.SortOrder;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
+import io.github.zhztheplayer.velox4j.variant.BooleanValue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -91,5 +94,15 @@ public class PlanNodeSerdeTest {
         List.of("foo"),
         List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")));
     SerdeTests.testVeloxSerializableRoundTrip(projectNode);
+  }
+
+  @Test
+  public void testFilterNode() {
+    final JniApi jniApi = JniApi.create(MemoryManager.create(AllocationListener.NOOP));
+    final PlanNode scan = SerdeTests.newSampleTableScanNode();
+    final FilterNode filterNode = new FilterNode("id-1", List.of(scan),
+        ConstantTypedExpr.create(jniApi, new BooleanValue(true)));
+    SerdeTests.testVeloxSerializableRoundTrip(filterNode);
+    jniApi.close();
   }
 }

--- a/src/test/resources/query-output/tpch-nation-filter-1.tsv
+++ b/src/test/resources/query-output/tpch-nation-filter-1.tsv
@@ -1,0 +1,11 @@
+n_nationkey	n_name	n_regionkey	n_comment
+4	EGYPT	4	y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
+6	FRANCE	3	refully final requests. regular, ironi
+7	GERMANY	3	l platelets. regular accounts x-ray: unusual, regular acco
+10	IRAN	4	efully alongside of the slyly final dependencies.
+11	IRAQ	4	nic deposits boost atop the quickly final requests? quickly regula
+13	JORDAN	4	ic deposits are blithely about the carefully regular pa
+19	ROMANIA	3	ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account
+20	SAUDI ARABIA	4	ts. silent requests haggle. closely express packages sleep across the blithely
+22	RUSSIA	3	requests against the platelets use never according to the quickly regular pint
+23	UNITED KINGDOM	3	eans boost carefully special requests. accounts are. carefull


### PR DESCRIPTION
The PR adds `FilterNode` that was already supported by velox to velox4j.

For reference about adding new velox features to velox4j, see also https://github.com/velox4j/velox4j/pull/12.