### PR TITLE
Add OrderByNode

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/OrderByNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/OrderByNode.java
@@ -1,0 +1,50 @@
+package io.github.zhztheplayer.velox4j.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
+import io.github.zhztheplayer.velox4j.sort.SortOrder;
+
+import java.util.List;
+
+public class OrderByNode extends PlanNode {
+  private final List<PlanNode> sources;
+  private final List<FieldAccessTypedExpr> sortingKeys;
+  private final List<SortOrder> sortingOrders;
+  private final boolean isPartial;
+
+  @JsonCreator
+  public OrderByNode(
+      @JsonProperty("id") String id,
+      @JsonProperty("sources") List<PlanNode> sources,
+      @JsonProperty("sortingKeys") List<FieldAccessTypedExpr> sortingKeys,
+      @JsonProperty("sortingOrders") List<SortOrder> sortingOrders,
+      @JsonProperty("partial") boolean isPartial) {
+    super(id);
+    this.sources = sources;
+    this.sortingKeys = sortingKeys;
+    this.sortingOrders = sortingOrders;
+    this.isPartial = isPartial;
+  }
+
+  @Override
+  protected List<PlanNode> getSources() {
+    return sources;
+  }
+
+  @JsonGetter("sortingKeys")
+  public List<FieldAccessTypedExpr> sortingKeys() {
+    return sortingKeys;
+  }
+
+  @JsonGetter("sortingOrders")
+  public List<SortOrder> sortingOrders() {
+    return sortingOrders;
+  }
+
+  @JsonGetter("partial")
+  public boolean isPartial() {
+    return isPartial;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
@@ -30,12 +30,12 @@ public class ProjectNode extends PlanNode {
   }
 
   @JsonGetter("names")
-  public List<String> names() {
+  public List<String> getNames() {
     return names;
   }
 
   @JsonGetter("projections")
-  public List<TypedExpr> projections() {
+  public List<TypedExpr> getProjections() {
     return projections;
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -19,6 +19,7 @@ import io.github.zhztheplayer.velox4j.filter.AlwaysTrue;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.HashJoinNode;
+import io.github.zhztheplayer.velox4j.plan.OrderByNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
@@ -130,6 +131,7 @@ public final class VeloxSerializables {
     NAME_REGISTRY.registerClass("ProjectNode", ProjectNode.class);
     NAME_REGISTRY.registerClass("FilterNode", FilterNode.class);
     NAME_REGISTRY.registerClass("HashJoinNode", HashJoinNode.class);
+    NAME_REGISTRY.registerClass("OrderByNode", OrderByNode.class);
   }
 
   private static void retisterConfig() {

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -155,7 +155,7 @@ public class QueryTest {
     );
     final List<BoundSplit> splits = List.of(
         new BoundSplit(
-            "id-2",
+            "id-1",
             -1,
             new ExternalStreamConnectorSplit("connector-external-stream", es.id())
         )

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -26,14 +26,17 @@ import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.HashJoinNode;
+import io.github.zhztheplayer.velox4j.plan.OrderByNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
+import io.github.zhztheplayer.velox4j.sort.SortOrder;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
 import io.github.zhztheplayer.velox4j.test.TpchTests;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
 import io.github.zhztheplayer.velox4j.type.BooleanType;
+import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.Type;
 import io.github.zhztheplayer.velox4j.type.VarCharType;
@@ -152,7 +155,7 @@ public class QueryTest {
     );
     final List<BoundSplit> splits = List.of(
         new BoundSplit(
-            "id-1",
+            "id-2",
             -1,
             new ExternalStreamConnectorSplit("connector-external-stream", es.id())
         )
@@ -239,6 +242,30 @@ public class QueryTest {
     UpIteratorTests.assertIterator(itr)
         .assertNumRowVectors(1)
         .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-join-1.tsv"))
+        .run();
+    jniApi.close();
+  }
+
+  @Test
+  public void testOrderBy() {
+    final JniApi jniApi = JniApi.create(memoryManager);
+    final File file = TpchTests.Table.NATION.file();
+    final RowType outputType = TpchTests.Table.NATION.schema();
+    final TableScanNode scanNode = newSampleScanNode("id-1", outputType);
+    final List<BoundSplit> splits = List.of(
+        newSampleSplit(scanNode, file)
+    );
+    final OrderByNode orderByNode = new OrderByNode("id-2", List.of(scanNode),
+        List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey"),
+            FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
+        List.of(new SortOrder(true, false),
+            new SortOrder(false, false)),
+        false);
+    final Query query = new Query(orderByNode, splits, Config.empty(), ConnectorConfig.empty());
+    final UpIterator itr = query.execute(jniApi);
+    UpIteratorTests.assertIterator(itr)
+        .assertNumRowVectors(1)
+        .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-orderby-1.tsv"))
         .run();
     jniApi.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -12,6 +12,7 @@ import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.HashJoinNode;
+import io.github.zhztheplayer.velox4j.plan.OrderByNode;
 import io.github.zhztheplayer.velox4j.plan.PlanNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
@@ -83,7 +84,7 @@ public class PlanNodeSerdeTest {
         SerdeTests.newSampleOutputType());
     final Aggregate aggregate = SerdeTests.newSampleAggregate();
     final AggregationNode aggregationNode = new AggregationNode(
-        "id-1",
+        "id-2",
         AggregateStep.PARTIAL,
         List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
         List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
@@ -101,7 +102,7 @@ public class PlanNodeSerdeTest {
   public void testProjectNode() {
     final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1",
         SerdeTests.newSampleOutputType());
-    final ProjectNode projectNode = new ProjectNode("id-1", List.of(scan),
+    final ProjectNode projectNode = new ProjectNode("id-2", List.of(scan),
         List.of("foo"),
         List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")));
     SerdeTests.testVeloxSerializableRoundTrip(projectNode);
@@ -112,7 +113,7 @@ public class PlanNodeSerdeTest {
     final JniApi jniApi = JniApi.create(MemoryManager.create(AllocationListener.NOOP));
     final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1",
         SerdeTests.newSampleOutputType());
-    final FilterNode filterNode = new FilterNode("id-1", List.of(scan),
+    final FilterNode filterNode = new FilterNode("id-2", List.of(scan),
         ConstantTypedExpr.create(jniApi, new BooleanValue(true)));
     SerdeTests.testVeloxSerializableRoundTrip(filterNode);
     jniApi.close();
@@ -141,5 +142,16 @@ public class PlanNodeSerdeTest {
         );
     SerdeTests.testVeloxSerializableRoundTrip(joinNode);
     jniApi.close();
+  }
+
+  @Test
+  public void testOrderByNode() {
+    final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1",
+        SerdeTests.newSampleOutputType());
+    final OrderByNode orderByNode = new OrderByNode("id-1", List.of(scan),
+        List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo1")),
+        List.of(new SortOrder(true, false)),
+        false);
+    SerdeTests.testVeloxSerializableRoundTrip(orderByNode);
   }
 }

--- a/src/test/resources/query-output/tpch-orderby-1.tsv
+++ b/src/test/resources/query-output/tpch-orderby-1.tsv
@@ -1,0 +1,26 @@
+n_nationkey	n_name	n_regionkey	n_comment
+16	MOZAMBIQUE	0	s. ironic, unusual asymptotes wake blithely r
+15	MOROCCO	0	rns. blithely bold courts among the closely regular packages use furiously bold platelets?
+14	KENYA	0	pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t
+5	ETHIOPIA	0	ven packages wake quickly. regu
+0	ALGERIA	0	haggle. carefully final deposits detect slyly agai
+24	UNITED STATES	1	y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+17	PERU	1	platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun
+3	CANADA	1	eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
+2	BRAZIL	1	y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special
+1	ARGENTINA	1	al foxes promise slyly according to the regular accounts. bold requests alon
+21	VIETNAM	2	hely enticingly express accounts. even, final
+18	CHINA	2	c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos
+12	JAPAN	2	ously. final, express gifts cajole a
+9	INDONESIA	2	slyly express asymptotes. regular deposits haggle slyly. carefully ironic hockey players sleep blithely. carefull
+8	INDIA	2	ss excuses cajole slyly across the packages. deposits print aroun
+23	UNITED KINGDOM	3	eans boost carefully special requests. accounts are. carefull
+22	RUSSIA	3	requests against the platelets use never according to the quickly regular pint
+19	ROMANIA	3	ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account
+7	GERMANY	3	l platelets. regular accounts x-ray: unusual, regular acco
+6	FRANCE	3	refully final requests. regular, ironi
+20	SAUDI ARABIA	4	ts. silent requests haggle. closely express packages sleep across the blithely
+13	JORDAN	4	ic deposits are blithely about the carefully regular pa
+11	IRAQ	4	nic deposits boost atop the quickly final requests? quickly regula
+10	IRAN	4	efully alongside of the slyly final dependencies.
+4	EGYPT	4	y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d


### PR DESCRIPTION
The PR adds `OrderByNode` that was already supported by velox to velox4j.

For reference about adding new velox features to velox4j, see also https://github.com/velox4j/velox4j/pull/12.