### PR TITLE
Add LimitNode

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/LimitNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/LimitNode.java
@@ -1,0 +1,48 @@
+package io.github.zhztheplayer.velox4j.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class LimitNode extends PlanNode {
+  private final List<PlanNode> sources;
+  private final long offset;
+  private final long count;
+  private final boolean partial;
+
+  @JsonCreator
+  public LimitNode(
+      @JsonProperty("id") String id,
+      @JsonProperty("sources") List<PlanNode> sources,
+      @JsonProperty("offset") long offset,
+      @JsonProperty("count") long count,
+      @JsonProperty("partial") boolean partial) {
+    super(id);
+    this.sources = sources;
+    this.offset = offset;
+    this.count = count;
+    this.partial = partial;
+  }
+
+  @Override
+  protected List<PlanNode> getSources() {
+    return sources;
+  }
+
+  @JsonGetter("offset")
+  public long getOffset() {
+    return offset;
+  }
+
+  @JsonGetter("count")
+  public long getCount() {
+    return count;
+  }
+
+  @JsonGetter("partial")
+  public boolean isPartial() {
+    return partial;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/OrderByNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/OrderByNode.java
@@ -12,7 +12,7 @@ public class OrderByNode extends PlanNode {
   private final List<PlanNode> sources;
   private final List<FieldAccessTypedExpr> sortingKeys;
   private final List<SortOrder> sortingOrders;
-  private final boolean isPartial;
+  private final boolean partial;
 
   @JsonCreator
   public OrderByNode(
@@ -20,12 +20,12 @@ public class OrderByNode extends PlanNode {
       @JsonProperty("sources") List<PlanNode> sources,
       @JsonProperty("sortingKeys") List<FieldAccessTypedExpr> sortingKeys,
       @JsonProperty("sortingOrders") List<SortOrder> sortingOrders,
-      @JsonProperty("partial") boolean isPartial) {
+      @JsonProperty("partial") boolean partial) {
     super(id);
     this.sources = sources;
     this.sortingKeys = sortingKeys;
     this.sortingOrders = sortingOrders;
-    this.isPartial = isPartial;
+    this.partial = partial;
   }
 
   @Override
@@ -45,6 +45,6 @@ public class OrderByNode extends PlanNode {
 
   @JsonGetter("partial")
   public boolean isPartial() {
-    return isPartial;
+    return partial;
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -19,6 +19,7 @@ import io.github.zhztheplayer.velox4j.filter.AlwaysTrue;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.HashJoinNode;
+import io.github.zhztheplayer.velox4j.plan.LimitNode;
 import io.github.zhztheplayer.velox4j.plan.OrderByNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
@@ -132,6 +133,7 @@ public final class VeloxSerializables {
     NAME_REGISTRY.registerClass("FilterNode", FilterNode.class);
     NAME_REGISTRY.registerClass("HashJoinNode", HashJoinNode.class);
     NAME_REGISTRY.registerClass("OrderByNode", OrderByNode.class);
+    NAME_REGISTRY.registerClass("LimitNode", LimitNode.class);
   }
 
   private static void retisterConfig() {

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -26,6 +26,7 @@ import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.HashJoinNode;
+import io.github.zhztheplayer.velox4j.plan.LimitNode;
 import io.github.zhztheplayer.velox4j.plan.OrderByNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.TableScanNode;
@@ -266,6 +267,25 @@ public class QueryTest {
     UpIteratorTests.assertIterator(itr)
         .assertNumRowVectors(1)
         .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-orderby-1.tsv"))
+        .run();
+    jniApi.close();
+  }
+
+  @Test
+  public void testLimit() {
+    final JniApi jniApi = JniApi.create(memoryManager);
+    final File file = TpchTests.Table.NATION.file();
+    final RowType outputType = TpchTests.Table.NATION.schema();
+    final TableScanNode scanNode = newSampleScanNode("id-1", outputType);
+    final List<BoundSplit> splits = List.of(
+        newSampleSplit(scanNode, file)
+    );
+    final LimitNode limitNode = new LimitNode("id-2", List.of(scanNode), 5, 3, false);
+    final Query query = new Query(limitNode, splits, Config.empty(), ConnectorConfig.empty());
+    final UpIterator itr = query.execute(jniApi);
+    UpIteratorTests.assertIterator(itr)
+        .assertNumRowVectors(1)
+        .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-limit-1.tsv"))
         .run();
     jniApi.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -155,7 +155,7 @@ public class QueryTest {
     );
     final List<BoundSplit> splits = List.of(
         new BoundSplit(
-            "id-2",
+            "id-1",
             -1,
             new ExternalStreamConnectorSplit("connector-external-stream", es.id())
         )

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -37,7 +37,6 @@ import io.github.zhztheplayer.velox4j.test.TpchTests;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
 import io.github.zhztheplayer.velox4j.type.BooleanType;
-import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.Type;
 import io.github.zhztheplayer.velox4j.type.VarCharType;

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -155,7 +155,7 @@ public class QueryTest {
     );
     final List<BoundSplit> splits = List.of(
         new BoundSplit(
-            "id-1",
+            "id-2",
             -1,
             new ExternalStreamConnectorSplit("connector-external-stream", es.id())
         )

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -12,6 +12,7 @@ import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
 import io.github.zhztheplayer.velox4j.plan.HashJoinNode;
+import io.github.zhztheplayer.velox4j.plan.LimitNode;
 import io.github.zhztheplayer.velox4j.plan.OrderByNode;
 import io.github.zhztheplayer.velox4j.plan.PlanNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
@@ -148,10 +149,18 @@ public class PlanNodeSerdeTest {
   public void testOrderByNode() {
     final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1",
         SerdeTests.newSampleOutputType());
-    final OrderByNode orderByNode = new OrderByNode("id-1", List.of(scan),
+    final OrderByNode orderByNode = new OrderByNode("id-2", List.of(scan),
         List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo1")),
         List.of(new SortOrder(true, false)),
         false);
     SerdeTests.testVeloxSerializableRoundTrip(orderByNode);
+  }
+
+  @Test
+  public void testLimitNode() {
+    final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1",
+        SerdeTests.newSampleOutputType());
+    final LimitNode limitNode = new LimitNode("id-2", List.of(scan), 5, 3, false);
+    SerdeTests.testVeloxSerializableRoundTrip(limitNode);
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -111,7 +111,7 @@ public class PlanNodeSerdeTest {
 
   @Test
   public void testFilterNode() {
-    final JniApi jniApi = JniApi.create(MemoryManager.create(AllocationListener.NOOP));
+    final JniApi jniApi = JniApi.create(memoryManager);
     final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1",
         SerdeTests.newSampleOutputType());
     final FilterNode filterNode = new FilterNode("id-2", List.of(scan),
@@ -122,7 +122,7 @@ public class PlanNodeSerdeTest {
 
   @Test
   public void testHashJoinNode() {
-    final JniApi jniApi = JniApi.create(MemoryManager.create(AllocationListener.NOOP));
+    final JniApi jniApi = JniApi.create(memoryManager);
     final PlanNode scan1 = SerdeTests.newSampleTableScanNode("id-1",
         new RowType(List.of("foo1", "bar1"),
             List.of(new IntegerType(), new IntegerType())));

--- a/src/test/resources/query-output/tpch-limit-1.tsv
+++ b/src/test/resources/query-output/tpch-limit-1.tsv
@@ -1,0 +1,4 @@
+n_nationkey	n_name	n_regionkey	n_comment
+5	ETHIOPIA	0	ven packages wake quickly. regu
+6	FRANCE	3	refully final requests. regular, ironi
+7	GERMANY	3	l platelets. regular accounts x-ray: unusual, regular acco


### PR DESCRIPTION
The PR adds `LimitNode` that was already supported by velox to velox4j.

For reference about adding new velox features to velox4j, see also https://github.com/velox4j/velox4j/pull/12.