### PR TITLE
Build: Exclude libpthread.so from installation

### DIFF
--- a/src/main/cpp/main/CMakeLists.txt
+++ b/src/main/cpp/main/CMakeLists.txt
@@ -49,4 +49,5 @@ install(RUNTIME_DEPENDENCY_SET 3rd DESTINATION lib COMPONENT velox4j PRE_EXCLUDE
         "linux-vdso\\.so\\.[0-9]+"
         "ld-linux-x86-64\\.so\\.[0-9]+"
         "libdl\\.so\\.[0-9]+"
+        "libpthread\\.so\\.[0-9]+"
 )


### PR DESCRIPTION
It seems `libpthread.so` sometimes has portability issues on some Linux distributions.

For example:

https://discussion.fedoraproject.org/t/lib64-libpthread-so-0-version-glibc-private-not-found/72557

The library should already be provided by system so exclude it from installation and the Jar.