### PR TITLE
Doc: Fix memory leak running the code example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ final UpIterator itr = query.execute(jniApi);
 // 8. Collect and print results.
 while (itr.hasNext()) {
   final RowVector rowVector = itr.next(); // 8.1. Get next RowVector returned by Velox.
-  final Table arrowTable = Arrow.toArrowTable(new RootAllocator(), rowVector); // 8.2. Convert the RowVector into Arrow format (an Arrow table in this case).
-  System.out.println(arrowTable.toVectorSchemaRoot().contentToTSVString()); // 8.3. Print the arrow table to stdout.
+  final VectorSchemaRoot vsr = Arrow.toArrowTable(new RootAllocator(), rowVector).toVectorSchemaRoot(); // 8.2. Convert the RowVector into Arrow format (an Arrow VectorSchemaRoot in this case).
+  System.out.println(vsr.contentToTSVString()); // 8.3. Print the arrow table to stdout.
+  vsr.close(); // 8.4. Release the Arrow VectorSchemaRoot.
 }
 
 // 9. Close the JNI session.


### PR DESCRIPTION
Update the example doc to avoid the following memory leak warning:

```
I0218 10:32:55.504593 1610254 Task.cpp:2052] Terminating task Task - EID 0 with state Finished after running for 183ms
E0218 10:32:55.505141 1610254 MemoryPool.cpp:435] [MEM] Memory leak (Used memory): Memory Pool[op.plan-id-1.0.0.TableScan LEAF root[root] parent[node.plan-id-1] MALLOC track-usage thread-safe]<unlimited max capacity unlimited capacity used 3.62KB available 1020.38KB reservation [used 3.62KB, reserved 1.00MB, min 0B] counters [allocs 35, frees 29, reserves 0, releases 1, collisions 0])>
E0218 10:32:55.505218 1610254 Exceptions.h:66] Line: /opt/velox4j/src/main/cpp/main/velox4j/memory/MemoryManager.cc:92, Function:removePool, Expression: pool->reservedBytes() == 0 (1048576 vs. 0), Source: RUNTIME, ErrorCode: INVALID_STATE
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (1048576 vs. 0)
Retriable: False
Expression: pool->reservedBytes() == 0
Function: removePool
File: /opt/velox4j/src/main/cpp/main/velox4j/memory/MemoryManager.cc
Line: 92
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 2  velox4j::(anonymous namespace)::ListenableArbitrator::removePool(facebook::velox::memory::MemoryPool*)
# 3  facebook::velox::memory::MemoryManager::dropPool(facebook::velox::memory::MemoryPool*)
# 4  facebook::velox::memory::MemoryPoolImpl::~MemoryPoolImpl()
# 5  velox4j::MemoryManager::tryDestructSafe()
# 6  velox4j::MemoryManager::~MemoryManager()
# 7  std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, std::shared_ptr<void> >, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<unsigned int const, std::shared_ptr<void> >, false>*) [clone .constprop.0]
# 8  velox4j::ResourceMap<std::shared_ptr<void> >::erase(unsigned int)
# 9  velox4j::ObjectStore::releaseInternal(unsigned int)
# 10 velox4j::(anonymous namespace)::releaseCppObject(JNIEnv_*, _jobject*, long)
# 11 0x00007fc46c7eba0f
# 12 0x00007fc46c7e6266
# 13 0x00007fc46c7e6266
# 14 0x00007fc46c7e6266
# 15 0x00007fc46c7dccc8
# 16 JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)
# 17 jni_invoke_static(JNIEnv_*, JavaValue*, _jobject*, JNICallType, _jmethodID*, JNI_ArgumentPusher*, Thread*) [clone .isra.71] [clone .constprop.342]
# 18 jni_CallStaticVoidMethod
# 19 JavaMain
# 20 ThreadJavaMain
# 21 start_thread
# 22 clone
```