### PR TITLE
Make static initialization procedure configurable

### DIFF
--- a/src/main/cpp/main/CMakeLists.txt
+++ b/src/main/cpp/main/CMakeLists.txt
@@ -20,6 +20,7 @@ set(VELOX4J_SOURCES
         velox4j/memory/MemoryManager.cc
         velox4j/memory/ArrowMemoryPool.cc
         velox4j/config/Config.cc
+        velox4j/init/Config.cc
 )
 set(VELOX4J_INCLUDES
         ${CMAKE_CURRENT_LIST_DIR}

--- a/src/main/cpp/main/velox4j/config/Config.cc
+++ b/src/main/cpp/main/velox4j/config/Config.cc
@@ -65,6 +65,11 @@ folly::dynamic ConfigArray::serialize() const {
 std::shared_ptr<ConfigArray> ConfigArray::create(
     const folly::dynamic& obj,
     void* context) {
+  return createSimple(obj);
+}
+
+std::shared_ptr<ConfigArray> ConfigArray::createSimple(
+    const folly::dynamic& obj) {
   std::vector<std::pair<std::string, std::string>> values;
   for (const auto& kv : obj["values"]) {
     values.emplace_back(kv["key"].asString(), kv["value"].asString());
@@ -75,6 +80,12 @@ std::shared_ptr<ConfigArray> ConfigArray::create(
 void ConfigArray::registerSerDe() {
   auto& registry = DeserializationWithContextRegistryForSharedPtr();
   registry.Register("Velox4jConfig", create);
+}
+
+std::shared_ptr<ConfigArray> ConfigArray::empty() {
+  static auto empty = std::make_shared<ConfigArray>(
+      std::vector<std::pair<std::string, std::string>>{});
+  return empty;
 }
 
 std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>

--- a/src/main/cpp/main/velox4j/config/Config.h
+++ b/src/main/cpp/main/velox4j/config/Config.h
@@ -1,38 +1,44 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once
 
-#include <velox/core/QueryConfig.h>
 #include <velox/common/serialization/Serializable.h>
+#include <velox/core/QueryConfig.h>
 
 namespace velox4j {
 using namespace facebook::velox;
 class ConfigArray : public ISerializable {
  public:
-  explicit ConfigArray(std::vector<std::pair<std::string, std::string>>&& values) : values_(std::move(values)) {}
+  explicit ConfigArray(
+      std::vector<std::pair<std::string, std::string>>&& values)
+      : values_(std::move(values)) {}
 
   std::unordered_map<std::string, std::string> toMap() const;
 
   folly::dynamic serialize() const override;
 
+  static std::shared_ptr<ConfigArray> empty();
+
   static std::shared_ptr<ConfigArray> create(
       const folly::dynamic& obj,
       void* context);
+
+  static std::shared_ptr<ConfigArray> createSimple(const folly::dynamic& obj);
 
   static void registerSerDe();
 
@@ -43,10 +49,12 @@ class ConfigArray : public ISerializable {
 class ConnectorConfigArray : public ISerializable {
  public:
   explicit ConnectorConfigArray(
-      std::vector<std::pair<std::string, std::shared_ptr<const ConfigArray>>>&& values)
+      std::vector<std::pair<std::string, std::shared_ptr<const ConfigArray>>>&&
+          values)
       : values_(std::move(values)) {}
 
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>> toMap() const;
+  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>> toMap()
+      const;
 
   folly::dynamic serialize() const override;
 
@@ -57,6 +65,7 @@ class ConnectorConfigArray : public ISerializable {
   static void registerSerDe();
 
  private:
-  const std::vector<std::pair<std::string, std::shared_ptr<const ConfigArray>>> values_;
+  const std::vector<std::pair<std::string, std::shared_ptr<const ConfigArray>>>
+      values_;
 };
-}
+} // namespace velox4j

--- a/src/main/cpp/main/velox4j/init/Config.cc
+++ b/src/main/cpp/main/velox4j/init/Config.cc
@@ -15,17 +15,8 @@
  * limitations under the License.
  */
 
-#include "velox4j/init/Config.h"
-#include "velox4j/init/Init.h"
-
-#pragma once
+#include "Config.h"
 
 namespace velox4j {
-void testingEnsureInitializedForSpark() {
-  static std::once_flag flag;
-  auto conf = std::make_shared<ConfigArray>(
-      std::vector<std::pair<std::string, std::string>>{
-          {VELOX4J_INIT_PRESET.key, folly::to<std::string>(Preset::SPARK)}});
-  std::call_once(flag, [&]() { initialize(conf); });
+ConfigBase::Entry<Preset> VELOX4J_INIT_PRESET("velox4j.init.preset", Preset::SPARK);
 }
-} // namespace velox4j

--- a/src/main/cpp/main/velox4j/init/Config.h
+++ b/src/main/cpp/main/velox4j/init/Config.h
@@ -15,17 +15,14 @@
  * limitations under the License.
  */
 
-#include "velox4j/init/Config.h"
-#include "velox4j/init/Init.h"
-
 #pragma once
 
+#include <velox/common/config/Config.h>
+
 namespace velox4j {
-void testingEnsureInitializedForSpark() {
-  static std::once_flag flag;
-  auto conf = std::make_shared<ConfigArray>(
-      std::vector<std::pair<std::string, std::string>>{
-          {VELOX4J_INIT_PRESET.key, folly::to<std::string>(Preset::SPARK)}});
-  std::call_once(flag, [&]() { initialize(conf); });
-}
+enum Preset { SPARK = 0 };
+
+using namespace facebook::velox::config;
+
+extern ConfigBase::Entry<Preset> VELOX4J_INIT_PRESET;
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/init/Init.cc
+++ b/src/main/cpp/main/velox4j/init/Init.cc
@@ -30,6 +30,7 @@
 #include <velox/functions/sparksql/window/WindowFunctionsRegistration.h>
 #include "velox4j/config/Config.h"
 #include "velox4j/connector/ExternalStream.h"
+#include "velox4j/init/Config.h"
 #include "velox4j/query/Query.h"
 
 namespace velox4j {
@@ -45,56 +46,68 @@ void init(const std::function<void()>& f) {
   }
   f();
 }
-} // namespace
 
 void initForSpark() {
-  init([]() -> void {
-    config::globalConfig().memoryLeakCheckEnabled = true;
-    config::globalConfig().memoryPoolCapacityTransferAcrossTasks = true;
-    config::globalConfig().exceptionSystemStacktraceEnabled = true;
-    config::globalConfig().exceptionUserStacktraceEnabled = true;
-    filesystems::registerLocalFileSystem();
-    memory::MemoryManager::initialize({});
-    dwio::common::registerFileSinks();
-    parquet::registerParquetReaderFactory();
-    parquet::registerParquetWriterFactory();
-    functions::sparksql::registerFunctions();
-    aggregate::prestosql::registerAllAggregateFunctions(
-        "",
-        true /*registerCompanionFunctions*/,
-        false /*onlyPrestoSignatures*/,
-        true /*overwrite*/);
-    functions::aggregate::sparksql::registerAggregateFunctions(
-        "", true /*registerCompanionFunctions*/, true /*overwrite*/);
-    window::prestosql::registerAllWindowFunctions();
-    functions::window::sparksql::registerWindowFunctions("");
+  config::globalConfig().memoryLeakCheckEnabled = true;
+  config::globalConfig().memoryPoolCapacityTransferAcrossTasks = true;
+  config::globalConfig().exceptionSystemStacktraceEnabled = true;
+  config::globalConfig().exceptionUserStacktraceEnabled = true;
+  filesystems::registerLocalFileSystem();
+  memory::MemoryManager::initialize({});
+  dwio::common::registerFileSinks();
+  parquet::registerParquetReaderFactory();
+  parquet::registerParquetWriterFactory();
+  functions::sparksql::registerFunctions();
+  aggregate::prestosql::registerAllAggregateFunctions(
+      "",
+      true /*registerCompanionFunctions*/,
+      false /*onlyPrestoSignatures*/,
+      true /*overwrite*/);
+  functions::aggregate::sparksql::registerAggregateFunctions(
+      "", true /*registerCompanionFunctions*/, true /*overwrite*/);
+  window::prestosql::registerAllWindowFunctions();
+  functions::window::sparksql::registerWindowFunctions("");
 
-    ConfigArray::registerSerDe();
-    ConnectorConfigArray::registerSerDe();
-    Query::registerSerDe();
-    Type::registerSerDe();
-    common::Filter::registerSerDe();
-    connector::hive::HiveTableHandle::registerSerDe();
-    connector::hive::LocationHandle::registerSerDe();
-    connector::hive::HiveColumnHandle::registerSerDe();
-    connector::hive::HiveInsertTableHandle::registerSerDe();
-    connector::hive::HiveConnectorSplit::registerSerDe();
-    connector::hive::registerHivePartitionFunctionSerDe();
-    connector::registerConnector(
-        std::make_shared<connector::hive::HiveConnector>(
-            "connector-hive",
-            std::make_shared<facebook::velox::config::ConfigBase>(
-                std::unordered_map<std::string, std::string>()),
-            nullptr));
-    ExternalStreamConnectorSplit::registerSerDe();
-    ExternalStreamTableHandle::registerSerDe();
-    connector::registerConnector(std::make_shared<ExternalStreamConnector>(
-        "connector-external-stream",
-        std::make_shared<facebook::velox::config::ConfigBase>(
-            std::unordered_map<std::string, std::string>())));
-    core::PlanNode::registerSerDe();
-    core::ITypedExpr::registerSerDe();
-    exec::registerPartitionFunctionSerDe();
+  ConfigArray::registerSerDe();
+  ConnectorConfigArray::registerSerDe();
+  Query::registerSerDe();
+  Type::registerSerDe();
+  common::Filter::registerSerDe();
+  connector::hive::HiveTableHandle::registerSerDe();
+  connector::hive::LocationHandle::registerSerDe();
+  connector::hive::HiveColumnHandle::registerSerDe();
+  connector::hive::HiveInsertTableHandle::registerSerDe();
+  connector::hive::HiveConnectorSplit::registerSerDe();
+  connector::hive::registerHivePartitionFunctionSerDe();
+  connector::registerConnector(std::make_shared<connector::hive::HiveConnector>(
+      "connector-hive",
+      std::make_shared<facebook::velox::config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()),
+      nullptr));
+  ExternalStreamConnectorSplit::registerSerDe();
+  ExternalStreamTableHandle::registerSerDe();
+  connector::registerConnector(std::make_shared<ExternalStreamConnector>(
+      "connector-external-stream",
+      std::make_shared<facebook::velox::config::ConfigBase>(
+          std::unordered_map<std::string, std::string>())));
+  core::PlanNode::registerSerDe();
+  core::ITypedExpr::registerSerDe();
+  exec::registerPartitionFunctionSerDe();
+}
+} // namespace
+
+void initialize(const std::shared_ptr<ConfigArray>& configArray) {
+  init([&]() -> void {
+    auto vConfig = std::make_shared<facebook::velox::config::ConfigBase>(
+        configArray->toMap());
+    auto preset = vConfig->get(VELOX4J_INIT_PRESET);
+    switch (preset) {
+      case SPARK:
+        initForSpark();
+        break;
+      default:
+        VELOX_FAIL("Unknown preset: {}", folly::to<std::string>(preset));
+    }
   });
 }
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/init/Init.cc
+++ b/src/main/cpp/main/velox4j/init/Init.cc
@@ -20,8 +20,6 @@
 #include <velox/connectors/hive/HiveConnector.h>
 #include <velox/connectors/hive/HiveConnectorSplit.h>
 #include <velox/connectors/hive/HiveDataSink.h>
-#include <velox/connectors/hive/TableHandle.h>
-#include <velox/core/PlanNode.h>
 #include <velox/dwio/parquet/RegisterParquetReader.h>
 #include <velox/dwio/parquet/RegisterParquetWriter.h>
 #include <velox/exec/PartitionFunction.h>
@@ -30,7 +28,6 @@
 #include <velox/functions/sparksql/aggregates/Register.h>
 #include <velox/functions/sparksql/registration/Register.h>
 #include <velox/functions/sparksql/window/WindowFunctionsRegistration.h>
-#include <velox/type/Filter.h>
 #include "velox4j/config/Config.h"
 #include "velox4j/connector/ExternalStream.h"
 #include "velox4j/query/Query.h"

--- a/src/main/cpp/main/velox4j/init/Init.h
+++ b/src/main/cpp/main/velox4j/init/Init.h
@@ -1,22 +1,24 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #pragma once
 
+#include "velox4j/config/Config.h"
+
 namespace velox4j {
-  void initForSpark();
-}
+void initialize(const std::shared_ptr<ConfigArray>& configArray);
+} // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/JniLoader.cc
+++ b/src/main/cpp/main/velox4j/jni/JniLoader.cc
@@ -20,7 +20,6 @@
 #include <jni.h>
 #include "JniWrapper.h"
 #include "StaticJniWrapper.h"
-#include "velox4j/init/Init.h"
 #include "velox4j/jni/JniError.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/iterator/DownIterator.h"
@@ -34,7 +33,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* jvm, void*) {
   }
 
   velox4j::getJniErrorState()->ensureInitialized(env);
-  velox4j::initForSpark();
   velox4j::jniClassRegistry()->add(env, new velox4j::StaticJniWrapper(env));
   velox4j::jniClassRegistry()->add(env, new velox4j::JniWrapper(env));
   velox4j::jniClassRegistry()->add(env, new velox4j::DownIteratorJniWrapper(env));

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -29,10 +29,12 @@ namespace {
 const char* kClassName = "io/github/zhztheplayer/velox4j/jni/StaticJniWrapper";
 
 void initialize0(JNIEnv* env, jobject javaThis, jstring globalConfJson) {
+  JNI_METHOD_START
   spotify::jni::JavaString jGlobalConfJson{env, globalConfJson};
   auto dynamic = folly::parseJson(jGlobalConfJson.get());
   auto confArray = ConfigArray::createSimple(dynamic);
   initialize(confArray);
+  JNI_METHOD_END()
 }
 
 jlong createMemoryManager(JNIEnv* env, jobject javaThis, jobject jListener) {

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -1,23 +1,26 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The ASF licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "StaticJniWrapper.h"
+#include <folly/json/json.h>
 #include "JniCommon.h"
 #include "JniError.h"
+#include "velox4j/config/Config.h"
+#include "velox4j/init/Init.h"
 #include "velox4j/lifecycle/Session.h"
 #include "velox4j/memory/JavaAllocationListener.h"
 
@@ -25,7 +28,14 @@ namespace velox4j {
 namespace {
 const char* kClassName = "io/github/zhztheplayer/velox4j/jni/StaticJniWrapper";
 
-long createMemoryManager(JNIEnv* env, jobject javaThis, jobject jListener) {
+void initialize0(JNIEnv* env, jobject javaThis, jstring globalConfJson) {
+  spotify::jni::JavaString jGlobalConfJson{env, globalConfJson};
+  auto dynamic = folly::parseJson(jGlobalConfJson.get());
+  auto confArray = ConfigArray::createSimple(dynamic);
+  initialize(confArray);
+}
+
+jlong createMemoryManager(JNIEnv* env, jobject javaThis, jobject jListener) {
   JNI_METHOD_START
   auto listener = std::make_unique<BlockAllocationListener>(
       std::make_unique<JavaAllocationListener>(env, jListener), 8 << 10 << 10);
@@ -34,7 +44,7 @@ long createMemoryManager(JNIEnv* env, jobject javaThis, jobject jListener) {
   JNI_METHOD_END(-1L)
 }
 
-long createSession(JNIEnv* env, jobject javaThis, long memoryManagerId) {
+jlong createSession(JNIEnv* env, jobject javaThis, long memoryManagerId) {
   JNI_METHOD_START
   auto mm = ObjectStore::retrieve<MemoryManager>(memoryManagerId);
   return ObjectStore::global()->save(std::make_unique<Session>(mm.get()));
@@ -47,7 +57,7 @@ void releaseCppObject(JNIEnv* env, jobject javaThis, jlong objId) {
   JNI_METHOD_END()
 }
 
-}
+} // namespace
 
 const char* StaticJniWrapper::getCanonicalName() const {
   return kClassName;
@@ -56,6 +66,8 @@ const char* StaticJniWrapper::getCanonicalName() const {
 void StaticJniWrapper::initialize(JNIEnv* env) {
   JavaClass::setClass(env);
 
+  addNativeMethod(
+      "initialize", (void*)initialize0, kTypeVoid, kTypeString, nullptr);
   addNativeMethod(
       "createMemoryManager",
       (void*)createMemoryManager,
@@ -74,8 +86,5 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
   registerNativeMethods(env);
 }
 
-void StaticJniWrapper::mapFields() {
-
-}
-}
-
+void StaticJniWrapper::mapFields() {}
+} // namespace velox4j

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.cc
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.cc
@@ -293,14 +293,19 @@ velox::memory::MemoryPool* MemoryManager::getVeloxPool(
   }
   switch (kind) {
     case velox::memory::MemoryPool::Kind::kLeaf: {
-      auto pool = veloxRootPool_->addLeafChild(name, true, velox::memory::MemoryReclaimer::create());
+      auto pool = veloxRootPool_->addLeafChild(
+          name, true, velox::memory::MemoryReclaimer::create());
       veloxPoolRefs_[name] = pool;
       return pool.get();
     }
     case velox::memory::MemoryPool::Kind::kAggregate: {
-      auto pool = veloxRootPool_->addAggregateChild(name, velox::memory::MemoryReclaimer::create());
+      auto pool = veloxRootPool_->addAggregateChild(
+          name, velox::memory::MemoryReclaimer::create());
       veloxPoolRefs_[name] = pool;
       return pool.get();
+    }
+    default: {
+      VELOX_FAIL("Unexpected memory pool kind");
     }
   }
   VELOX_FAIL("Unreachable code");

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -1,7 +1,9 @@
 package io.github.zhztheplayer.velox4j.jni;
 
+import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
+import io.github.zhztheplayer.velox4j.serde.Serde;
 
 public class StaticJniApi {
   private static final StaticJniApi INSTANCE = new StaticJniApi();
@@ -13,6 +15,10 @@ public class StaticJniApi {
   private final StaticJniWrapper jni = StaticJniWrapper.get();
 
   private StaticJniApi() {}
+
+  public void initialize(Config globalConf) {
+    jni.initialize(Serde.toPrettyJson(globalConf));
+  }
 
   public MemoryManager createMemoryManager(AllocationListener listener) {
     return new MemoryManager(jni.createMemoryManager(listener));

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -11,6 +11,9 @@ public class StaticJniWrapper {
 
   private StaticJniWrapper() {}
 
+  // Global initialization.
+  native void initialize(String globalConfJson);
+
   // Memory.
   native long createMemoryManager(AllocationListener listener);
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -65,6 +65,7 @@ public final class VeloxSerializables {
     registerConnectors();
     registerFilters();
     registerPlanNodes();
+    retisterConfig();
     registerQuery();
   }
 
@@ -133,6 +134,11 @@ public final class VeloxSerializables {
     NAME_REGISTRY.registerClass("HashJoinNode", HashJoinNode.class);
     NAME_REGISTRY.registerClass("OrderByNode", OrderByNode.class);
     NAME_REGISTRY.registerClass("LimitNode", LimitNode.class);
+  }
+
+  private static void retisterConfig() {
+    NAME_REGISTRY.registerClass("Velox4jConfig", Config.class);
+    NAME_REGISTRY.registerClass("Velox4jConnectorConfig", ConnectorConfig.class);
   }
 
   private static void registerQuery() {

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -65,7 +65,6 @@ public final class VeloxSerializables {
     registerConnectors();
     registerFilters();
     registerPlanNodes();
-    retisterConfig();
     registerQuery();
   }
 
@@ -134,11 +133,6 @@ public final class VeloxSerializables {
     NAME_REGISTRY.registerClass("HashJoinNode", HashJoinNode.class);
     NAME_REGISTRY.registerClass("OrderByNode", OrderByNode.class);
     NAME_REGISTRY.registerClass("LimitNode", LimitNode.class);
-  }
-
-  private static void retisterConfig() {
-    NAME_REGISTRY.registerClass("Velox4jConfig", Config.class);
-    NAME_REGISTRY.registerClass("Velox4jConnectorConfig", ConnectorConfig.class);
   }
 
   private static void registerQuery() {


### PR DESCRIPTION
Add configuration option `velox4j.init.preset` to make the code be able to have more initialization presets than `initForSpark`.

The supported values of the option follows [this enum](https://github.com/zhztheplayer/velox4j/blob/4a3477ed470231cda778ad698a62d56d330616cb/src/main/cpp/main/velox4j/init/Config.h#L23).