### PR TITLE
Move API `Velox4j.ensureInitialized()` to test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The following is a brief example of using Velox4j to execute a query:
 
 ```java
 // 1. Initialize Velox4j.
-Velox4j.ensureInitialized();
+Velox4j.initialize();
 
 // 2. Define the plan output schema.
 final RowType outputType = new RowType(List.of(

--- a/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
@@ -31,7 +31,7 @@ public class Velox4j {
       }
       // If Velox4j was already initialized, throw.
       if (initialized.get()) {
-        throw new VeloxException("Velox4J has already been initialized");
+        throw new VeloxException("Could not change configuration after Velox4j was already initialized");
       }
       // Apply the configuration change.
       globalConfMap.put(key, value);
@@ -41,13 +41,6 @@ public class Velox4j {
   public static void initialize() {
     if (!initialized.compareAndSet(false, true)) {
       throw new VeloxException("Velox4J has already been initialized");
-    }
-    initialize0();
-  }
-
-  public static void ensureInitialized() {
-    if (!initialized.compareAndSet(false, true)) {
-      return;
     }
     initialize0();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -17,7 +17,6 @@
 
 package io.github.zhztheplayer.velox4j.jni;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.connector.ExternalStream;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
@@ -27,8 +26,9 @@ import io.github.zhztheplayer.velox4j.iterator.DownIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
-import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
+import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.DoubleType;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RealType;
@@ -52,7 +52,7 @@ public class JniApiTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
     memoryManager = MemoryManager.create(AllocationListener.NOOP);
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -1,6 +1,5 @@
 package io.github.zhztheplayer.velox4j.query;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
 import io.github.zhztheplayer.velox4j.config.Config;
@@ -35,6 +34,7 @@ import io.github.zhztheplayer.velox4j.test.ResourceTests;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
 import io.github.zhztheplayer.velox4j.test.TpchTests;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
 import io.github.zhztheplayer.velox4j.type.BooleanType;
 import io.github.zhztheplayer.velox4j.type.RowType;
@@ -57,7 +57,7 @@ public class QueryTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
     memoryManager = MemoryManager.create(AllocationListener.NOOP);
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/ConfigSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/ConfigSerdeTest.java
@@ -1,8 +1,8 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.config.ConnectorConfig;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -13,7 +13,7 @@ import java.util.UUID;
 public class ConfigSerdeTest {
   @BeforeClass
   public static void beforeClass() {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/ConnectorSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/ConnectorSerdeTest.java
@@ -1,6 +1,5 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.connector.Assignment;
 import io.github.zhztheplayer.velox4j.connector.ColumnHandle;
 import io.github.zhztheplayer.velox4j.connector.ConnectorSplit;
@@ -12,6 +11,7 @@ import io.github.zhztheplayer.velox4j.connector.FileProperties;
 import io.github.zhztheplayer.velox4j.connector.RowIdProperties;
 import io.github.zhztheplayer.velox4j.connector.SubfieldFilter;
 import io.github.zhztheplayer.velox4j.filter.AlwaysTrue;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -21,7 +21,7 @@ import java.util.OptionalLong;
 public class ConnectorSerdeTest {
   @BeforeClass
   public static void beforeClass() {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/ExprSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/ExprSerdeTest.java
@@ -1,6 +1,5 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.CastTypedExpr;
@@ -13,6 +12,7 @@ import io.github.zhztheplayer.velox4j.expression.LambdaTypedExpr;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.BooleanType;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RealType;
@@ -32,7 +32,7 @@ public class ExprSerdeTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
     memoryManager = MemoryManager.create(AllocationListener.NOOP);
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/FilterSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/FilterSerdeTest.java
@@ -1,7 +1,7 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.filter.AlwaysTrue;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -9,7 +9,7 @@ public class FilterSerdeTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -1,6 +1,5 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
 import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
@@ -18,6 +17,7 @@ import io.github.zhztheplayer.velox4j.plan.PlanNode;
 import io.github.zhztheplayer.velox4j.plan.ProjectNode;
 import io.github.zhztheplayer.velox4j.plan.ValuesNode;
 import io.github.zhztheplayer.velox4j.sort.SortOrder;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.variant.BooleanValue;
@@ -32,7 +32,7 @@ public class PlanNodeSerdeTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
     memoryManager = MemoryManager.create(AllocationListener.NOOP);
   }
 
@@ -140,7 +140,7 @@ public class PlanNodeSerdeTest {
         new RowType(List.of("foo1", "bar1", "foo2", "bar2"),
             List.of(new IntegerType(), new IntegerType(), new IntegerType(), new IntegerType())),
         false
-        );
+    );
     SerdeTests.testVeloxSerializableRoundTrip(joinNode);
     jniApi.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/QuerySerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/QuerySerdeTest.java
@@ -1,8 +1,8 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.query.Query;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -10,7 +10,7 @@ public class QuerySerdeTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypeSerdeTest.java
@@ -1,8 +1,28 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
-import io.github.zhztheplayer.velox4j.type.*;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
+import io.github.zhztheplayer.velox4j.type.ArrayType;
+import io.github.zhztheplayer.velox4j.type.BigIntType;
+import io.github.zhztheplayer.velox4j.type.BooleanType;
+import io.github.zhztheplayer.velox4j.type.DateType;
+import io.github.zhztheplayer.velox4j.type.DecimalType;
+import io.github.zhztheplayer.velox4j.type.DoubleType;
+import io.github.zhztheplayer.velox4j.type.FunctionType;
+import io.github.zhztheplayer.velox4j.type.HugeIntType;
+import io.github.zhztheplayer.velox4j.type.IntegerType;
+import io.github.zhztheplayer.velox4j.type.IntervalDayTimeType;
+import io.github.zhztheplayer.velox4j.type.IntervalYearMonthType;
+import io.github.zhztheplayer.velox4j.type.MapType;
+import io.github.zhztheplayer.velox4j.type.OpaqueType;
+import io.github.zhztheplayer.velox4j.type.RealType;
+import io.github.zhztheplayer.velox4j.type.RowType;
+import io.github.zhztheplayer.velox4j.type.SmallIntType;
+import io.github.zhztheplayer.velox4j.type.TimestampType;
+import io.github.zhztheplayer.velox4j.type.TinyIntType;
+import io.github.zhztheplayer.velox4j.type.UnknownType;
+import io.github.zhztheplayer.velox4j.type.VarCharType;
+import io.github.zhztheplayer.velox4j.type.VarbinaryType;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -13,7 +33,7 @@ public class TypeSerdeTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
@@ -1,7 +1,7 @@
 package io.github.zhztheplayer.velox4j.serde;
 
-import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.variant.ArrayValue;
 import io.github.zhztheplayer.velox4j.variant.BigIntValue;
 import io.github.zhztheplayer.velox4j.variant.BooleanValue;
@@ -27,7 +27,7 @@ import java.util.Map;
 public class VariantSerdeTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
-    Velox4j.ensureInitialized();
+    Velox4jTests.ensureInitialized();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/Velox4jTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/Velox4jTests.java
@@ -1,0 +1,16 @@
+package io.github.zhztheplayer.velox4j.test;
+
+import io.github.zhztheplayer.velox4j.Velox4j;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Velox4jTests {
+  private static final AtomicBoolean initialized = new AtomicBoolean(false);
+
+  public static void ensureInitialized() {
+    if (!initialized.compareAndSet(false, true)) {
+      return;
+    }
+    Velox4j.initialize();
+  }
+}


### PR DESCRIPTION
Avoid providing idempotent `init` API to force user fully control the static initialization procedure.