### PR TITLE
Cleanup JNI workspace on process start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.13.1</junit.version>
     <arrow.version>18.1.0</arrow.version>
-    <guava.version>33.3.1-jre</guava.version>
+    <guava.version>33.4.0-jre</guava.version>
+    <commons-io.version>2.18.0</commons-io.version>
     <jackson.version>2.18.0</jackson.version>
     <surefire.add-opens.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED
     </surefire.add-opens.argLine>
@@ -222,15 +223,20 @@
       <version>${arrow.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
@@ -48,7 +48,7 @@ public class Velox4j {
   private static void initialize0() {
     synchronized (globalConfMap) {
       final Config globalConf = Config.create(globalConfMap);
-      JniLibLoader.loadAll(JniWorkspace.getDefault().getWorkDir());
+      JniLibLoader.loadAll(JniWorkspace.getDefault().getSubDir("lib"));
       Variants.registerAll();
       VeloxSerializables.registerAll();
       StaticJniApi.get().initialize(globalConf);

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
@@ -29,7 +29,7 @@ public class JniLibLoader {
     final ResourceFile velox4jLibFile = velox4jLibFiles.get(0);
     for (ResourceFile libFile : libFiles) {
       final File copied = workDir.toPath().resolve(libFile.name()).toFile();
-      System.out.printf("Copying library %s to %s...\n", libFile.name(), copied);
+      System.out.printf("Copying library %s to %s...%n", libFile.name(), copied);
       libFile.copyTo(copied);
     }
     final File copiedVelox4jLib = workDir.toPath().resolve(velox4jLibFile.name()).toFile();

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/ResourceTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/ResourceTests.java
@@ -1,6 +1,7 @@
 package io.github.zhztheplayer.velox4j.test;
 
 import com.google.common.base.Preconditions;
+import io.github.zhztheplayer.velox4j.jni.JniWorkspace;
 import io.github.zhztheplayer.velox4j.resource.Resources;
 
 import java.io.BufferedOutputStream;
@@ -34,7 +35,8 @@ public final class ResourceTests {
 
   public static File copyResourceToTmp(String path) {
     try {
-      final File tmp = File.createTempFile("velox4j-test-", ".tmp");
+      final File folder = JniWorkspace.getDefault().getSubDir("test");
+      final File tmp = File.createTempFile("velox4j-test-", ".tmp", folder);
       Resources.copyResource(path, tmp);
       return tmp;
     } catch (IOException e) {


### PR DESCRIPTION
This makes velox4j use a temporary folder `/tmp/velox4j-1609902915266301671` constantly. The folder will be cleared every time the JVM is started.