### PR TITLE
Add SelectivityVector API

### DIFF
--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -124,6 +124,15 @@ jlong baseVectorNewRef(JNIEnv* env, jobject javaThis, jlong vid) {
   JNI_METHOD_END(-1)
 }
 
+jlong createSelectivityVector(JNIEnv* env, jobject javaThis, jint length) {
+  JNI_METHOD_START
+  auto session = sessionOf(env, javaThis);
+  auto vector =
+      std::make_shared<SelectivityVector>(static_cast<vector_size_t>(length));
+  return sessionOf(env, javaThis)->objectStore()->save(vector);
+  JNI_METHOD_END(-1)
+}
+
 jstring deserializeAndSerialize(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
@@ -215,6 +224,12 @@ void JniWrapper::initialize(JNIEnv* env) {
       (void*)baseVectorNewRef,
       kTypeLong,
       kTypeLong,
+      nullptr);
+  addNativeMethod(
+      "createSelectivityVector",
+      (void*)createSelectivityVector,
+      kTypeLong,
+      kTypeInt,
       nullptr);
   addNativeMethod(
       "deserializeAndSerialize",

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -132,6 +132,14 @@ jstring baseVectorGetEncoding(JNIEnv* env, jobject javaThis, jlong vid) {
   JNI_METHOD_END(nullptr)
 }
 
+jboolean selectivityVectorIsValid(JNIEnv* env, jobject javaThis, jlong svId, jint idx) {
+  JNI_METHOD_START
+  auto vector = ObjectStore::retrieve<SelectivityVector>(svId);
+  auto valid = vector->isValid(static_cast<vector_size_t>(idx));
+  return static_cast<jboolean>(valid);
+  JNI_METHOD_END(false)
+}
+
 jstring
 deserializeAndSerializeVariant(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_START
@@ -205,6 +213,13 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       (void*)baseVectorGetEncoding,
       kTypeString,
       kTypeLong,
+      nullptr);
+  addNativeMethod(
+      "selectivityVectorIsValid",
+      (void*)selectivityVectorIsValid,
+      kTypeBool,
+      kTypeLong,
+      kTypeInt,
       nullptr);
   addNativeMethod(
       "deserializeAndSerializeVariant",

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVector.java
@@ -1,0 +1,17 @@
+package io.github.zhztheplayer.velox4j.data;
+
+import io.github.zhztheplayer.velox4j.jni.CppObject;
+import io.github.zhztheplayer.velox4j.jni.JniApi;
+
+public class SelectivityVector implements CppObject {
+  private final long id;
+
+  public SelectivityVector(long id) {
+    this.id = id;
+  }
+
+  @Override
+  public long id() {
+    return id;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVectors.java
@@ -1,0 +1,20 @@
+package io.github.zhztheplayer.velox4j.data;
+
+import io.github.zhztheplayer.velox4j.jni.JniApi;
+import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
+
+public class SelectivityVectors {
+  private final JniApi jniApi;
+
+  public SelectivityVectors(JniApi jniApi) {
+    this.jniApi = jniApi;
+  }
+
+  public SelectivityVector create(int length) {
+    return jniApi.createSelectivityVector(length);
+  }
+
+  public static boolean isValid(SelectivityVector vector, int idx) {
+    return StaticJniApi.get().selectivityVectorIsValid(vector, idx);
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -3,6 +3,7 @@ package io.github.zhztheplayer.velox4j.jni;
 import com.google.common.annotations.VisibleForTesting;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.data.SelectivityVector;
 import io.github.zhztheplayer.velox4j.data.VectorEncoding;
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.iterator.DownIterator;
@@ -82,6 +83,10 @@ public final class JniApi {
 
   public RowVector baseVectorAsRowVector(BaseVector vector) {
     return rowVectorWrap(jni.baseVectorNewRef(vector.id()));
+  }
+
+  public SelectivityVector createSelectivityVector(int length) {
+    return new SelectivityVector(jni.createSelectivityVector(length));
   }
 
   @VisibleForTesting

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -46,11 +46,12 @@ final class JniWrapper {
   // For DownIterator.
   native long newExternalStream(DownIterator itr);
 
-  // For BaseVector / RowVector.
+  // For BaseVector / RowVector / SelectivityVector.
   native long arrowToBaseVector(long cSchema, long cArray);
   native long[] baseVectorDeserialize(String serialized);
   native long baseVectorWrapInConstant(long id, int length, int index);
   native long baseVectorNewRef(long id);
+  native long createSelectivityVector(int length);
 
   // For test.
   @VisibleForTesting

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/LocalSession.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/LocalSession.java
@@ -5,6 +5,7 @@ import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.connector.ExternalStreams;
 import io.github.zhztheplayer.velox4j.data.BaseVectors;
 import io.github.zhztheplayer.velox4j.data.RowVectors;
+import io.github.zhztheplayer.velox4j.data.SelectivityVectors;
 import io.github.zhztheplayer.velox4j.query.Queries;
 import io.github.zhztheplayer.velox4j.session.Session;
 
@@ -42,6 +43,11 @@ public class LocalSession implements Session {
   @Override
   public RowVectors rowVectorOps() {
     return new RowVectors(jniApi());
+  }
+
+  @Override
+  public SelectivityVectors selectivityVectorOps() {
+    return new SelectivityVectors(jniApi());
   }
 
   @Override

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -3,6 +3,7 @@ package io.github.zhztheplayer.velox4j.jni;
 import com.google.common.annotations.VisibleForTesting;
 import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
+import io.github.zhztheplayer.velox4j.data.SelectivityVector;
 import io.github.zhztheplayer.velox4j.data.VectorEncoding;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
@@ -24,7 +25,8 @@ public class StaticJniApi {
 
   private final StaticJniWrapper jni = StaticJniWrapper.get();
 
-  private StaticJniApi() {}
+  private StaticJniApi() {
+  }
 
   public void initialize(Config globalConf) {
     jni.initialize(Serde.toPrettyJson(globalConf));
@@ -67,6 +69,10 @@ public class StaticJniApi {
 
   public VectorEncoding baseVectorGetEncoding(BaseVector vector) {
     return VectorEncoding.valueOf(jni.baseVectorGetEncoding(vector.id()));
+  }
+
+  public boolean selectivityVectorIsValid(SelectivityVector vector, int idx) {
+    return jni.selectivityVectorIsValid(vector.id(), idx);
   }
 
   @VisibleForTesting

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -28,11 +28,12 @@ public class StaticJniWrapper {
   // For Variant.
   native String variantInferType(String json);
 
-  // For BaseVector / RowVector.
+  // For BaseVector / RowVector / SelectivityVector.
   native void baseVectorToArrow(long rvAddress, long cSchema, long cArray);
   native String baseVectorSerialize(long[] id);
   native String baseVectorGetType(long id);
   native String baseVectorGetEncoding(long id);
+  native boolean selectivityVectorIsValid(long id, int idx);
 
   // For test.
   @VisibleForTesting

--- a/src/main/java/io/github/zhztheplayer/velox4j/session/Session.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/session/Session.java
@@ -4,6 +4,7 @@ import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.connector.ExternalStreams;
 import io.github.zhztheplayer.velox4j.data.BaseVectors;
 import io.github.zhztheplayer.velox4j.data.RowVectors;
+import io.github.zhztheplayer.velox4j.data.SelectivityVectors;
 import io.github.zhztheplayer.velox4j.jni.CppObject;
 import io.github.zhztheplayer.velox4j.query.Queries;
 
@@ -15,6 +16,8 @@ public interface Session extends CppObject {
   BaseVectors baseVectorOps();
 
   RowVectors rowVectorOps();
+
+  SelectivityVectors selectivityVectorOps();
 
   Arrow arrowOps();
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
@@ -1,0 +1,37 @@
+package io.github.zhztheplayer.velox4j.data;
+
+import io.github.zhztheplayer.velox4j.Velox4j;
+import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.MemoryManager;
+import io.github.zhztheplayer.velox4j.session.Session;
+import io.github.zhztheplayer.velox4j.test.Velox4jTests;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SelectivityVectorTest {
+  private static MemoryManager memoryManager;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Velox4jTests.ensureInitialized();
+    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    memoryManager.close();
+  }
+
+  @Test
+  public void testIsValid() {
+    final Session session = Velox4j.newSession(memoryManager);
+    final int length = 10;
+    final SelectivityVector sv = session.selectivityVectorOps().create(length);
+    for (int i = 0; i < length; i++) {
+      Assert.assertTrue(SelectivityVectors.isValid(sv, i));
+    }
+    session.close();
+  }
+}

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -17,7 +17,6 @@
 
 package io.github.zhztheplayer.velox4j.jni;
 
-import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.connector.ExternalStream;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
@@ -27,6 +26,7 @@ import io.github.zhztheplayer.velox4j.iterator.DownIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
+import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;


### PR DESCRIPTION
Add base API for `SelectivityVector`. The API is useful for future work of adding expression evaluator to Velox4j.