### PR TITLE
Rename serde keys of velox4j JSON beans with unified prefix `velox4j.`

### DIFF
--- a/src/main/cpp/main/velox4j/config/Config.cc
+++ b/src/main/cpp/main/velox4j/config/Config.cc
@@ -51,7 +51,7 @@ std::unordered_map<std::string, std::string> ConfigArray::toMap() const {
 
 folly::dynamic ConfigArray::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "Velox4jConfig";
+  obj["name"] = "velox4j.Config";
   folly::dynamic values = folly::dynamic::array;
   for (const auto& kv : values_) {
     folly::dynamic kvObj = folly::dynamic::object;
@@ -73,7 +73,7 @@ std::shared_ptr<ConfigArray> ConfigArray::create(const folly::dynamic& obj) {
 
 void ConfigArray::registerSerDe() {
   auto& registry = DeserializationRegistryForSharedPtr();
-  registry.Register("Velox4jConfig", create);
+  registry.Register("velox4j.Config", create);
 }
 
 std::shared_ptr<ConfigArray> ConfigArray::empty() {
@@ -98,7 +98,7 @@ ConnectorConfigArray::toMap() const {
 
 folly::dynamic ConnectorConfigArray::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "Velox4jConnectorConfig";
+  obj["name"] = "velox4j.ConnectorConfig";
   folly::dynamic values = folly::dynamic::array;
   for (const auto& kv : values_) {
     folly::dynamic kvObj = folly::dynamic::object;
@@ -124,6 +124,6 @@ std::shared_ptr<ConnectorConfigArray> ConnectorConfigArray::create(
 
 void ConnectorConfigArray::registerSerDe() {
   auto& registry = DeserializationRegistryForSharedPtr();
-  registry.Register("Velox4jConnectorConfig", create);
+  registry.Register("velox4j.ConnectorConfig", create);
 }
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/eval/Evaluation.cc
+++ b/src/main/cpp/main/velox4j/eval/Evaluation.cc
@@ -42,7 +42,7 @@ const std::shared_ptr<const ConnectorConfigArray>& Evaluation::connectorConfig()
 
 folly::dynamic Evaluation::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "Velox4jEvaluation";
+  obj["name"] = "velox4j.Evaluation";
   obj["expr"] = expr_->serialize();
   obj["queryConfig"] = queryConfig_->serialize();
   obj["connectorConfig"] = connectorConfig_->serialize();
@@ -64,7 +64,7 @@ std::shared_ptr<Evaluation> Evaluation::create(
 
 void Evaluation::registerSerDe() {
   auto& registry = DeserializationWithContextRegistryForSharedPtr();
-  registry.Register("Velox4jEvaluation", create);
+  registry.Register("velox4j.Evaluation", create);
 }
 
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/query/Query.cc
+++ b/src/main/cpp/main/velox4j/query/Query.cc
@@ -67,7 +67,7 @@ std::string Query::toString() const {
 
 folly::dynamic Query::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "Velox4jQuery";
+  obj["name"] = "velox4j.Query";
   obj["plan"] = plan_->serialize();
   folly::dynamic boundSplits = folly::dynamic::array;
   for (const auto& boundSplit : boundSplits_) {
@@ -106,6 +106,6 @@ std::shared_ptr<Query> Query::create(const folly::dynamic& obj, void* context) {
 
 void Query::registerSerDe() {
   auto& registry = DeserializationWithContextRegistryForSharedPtr();
-  registry.Register("Velox4jQuery", create);
+  registry.Register("velox4j.Query", create);
 }
 } // namespace velox4j

--- a/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serializable/VeloxSerializables.java
@@ -139,15 +139,15 @@ public final class VeloxSerializables {
   }
 
   private static void retisterConfig() {
-    NAME_REGISTRY.registerClass("Velox4jConfig", Config.class);
-    NAME_REGISTRY.registerClass("Velox4jConnectorConfig", ConnectorConfig.class);
+    NAME_REGISTRY.registerClass("velox4j.Config", Config.class);
+    NAME_REGISTRY.registerClass("velox4j.ConnectorConfig", ConnectorConfig.class);
   }
 
   private static void registerExpression() {
-    NAME_REGISTRY.registerClass("Velox4jEvaluation", Evaluation.class);
+    NAME_REGISTRY.registerClass("velox4j.Evaluation", Evaluation.class);
   }
 
   private static void registerQuery() {
-    NAME_REGISTRY.registerClass("Velox4jQuery", Query.class);
+    NAME_REGISTRY.registerClass("velox4j.Query", Query.class);
   }
 }

--- a/src/test/resources/query/example-1.json
+++ b/src/test/resources/query/example-1.json
@@ -1,5 +1,5 @@
 {
-  "name": "Velox4jQuery",
+  "name": "velox4j.Query",
   "plan": {
     "aggregateNames": [
       "a0",
@@ -208,7 +208,7 @@
   },
   "boundSplits": [],
   "queryConfig": {
-    "name": "Velox4jConfig",
+    "name": "velox4j.Config",
     "values": [
       {
         "key": "max_output_batch_rows",
@@ -221,12 +221,12 @@
     ]
   },
   "connectorConfig": {
-    "name": "Velox4jConnectorConfig",
+    "name": "velox4j.ConnectorConfig",
     "values": [
       {
         "connectorId": "conn-1",
         "config": {
-          "name": "Velox4jConfig",
+          "name": "velox4j.Config",
           "values": [
             {
               "key": "k1",
@@ -246,7 +246,7 @@
       {
         "connectorId": "conn-2",
         "config": {
-          "name": "Velox4jConfig",
+          "name": "velox4j.Config",
           "values": [
             {
               "key": "k5",


### PR DESCRIPTION
So the JSON beans defined by Velox4j will be easily distinguished from the original ones from Velox4j.