### PR TITLE
Inline some static APIs to relevant objects

### DIFF
--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -145,13 +145,6 @@ jlong baseVectorWrapInConstant(
   JNI_METHOD_END(-1)
 }
 
-jlong baseVectorNewRef(JNIEnv* env, jobject javaThis, jlong vid) {
-  JNI_METHOD_START
-  auto vector = ObjectStore::retrieve<BaseVector>(vid);
-  return sessionOf(env, javaThis)->objectStore()->save(vector);
-  JNI_METHOD_END(-1)
-}
-
 jlong createSelectivityVector(JNIEnv* env, jobject javaThis, jint length) {
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
@@ -260,12 +253,6 @@ void JniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       kTypeInt,
       kTypeInt,
-      nullptr);
-  addNativeMethod(
-      "baseVectorNewRef",
-      (void*)baseVectorNewRef,
-      kTypeLong,
-      kTypeLong,
       nullptr);
   addNativeMethod(
       "createSelectivityVector",

--- a/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
@@ -53,9 +53,7 @@ public class Arrow {
         final VectorSchemaRoot vsr = table.toVectorSchemaRoot()) {
       Data.exportVectorSchemaRoot(alloc, vsr, null, cArray, cSchema);
       final BaseVector imported = jniApi.arrowToBaseVector(cSchema, cArray);
-      Preconditions.checkState(imported instanceof RowVector,
-          "Expected RowVector, got %s", imported.getClass().getName());
-      return (RowVector) imported;
+      return imported.asRowVector();
     }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
@@ -8,6 +8,7 @@ import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.table.Table;
@@ -19,30 +20,42 @@ public class Arrow {
     this.jniApi = jniApi;
   }
 
-  public static Table toArrowTable(BufferAllocator alloc, RowVector vector) {
-    try (final ArrowSchema schema = ArrowSchema.allocateNew(alloc);
-        final ArrowArray array = ArrowArray.allocateNew(alloc)) {
-      StaticJniApi.get().baseVectorToArrow(vector, schema, array);
-      final VectorSchemaRoot vsr = Data.importVectorSchemaRoot(alloc, array, schema, null);
-      return new Table(vsr);
-    }
-  }
-
   public static FieldVector toArrowVector(BufferAllocator alloc, BaseVector vector) {
-    try (final ArrowSchema schema = ArrowSchema.allocateNew(alloc);
-        final ArrowArray array = ArrowArray.allocateNew(alloc)) {
-      StaticJniApi.get().baseVectorToArrow(vector, schema, array);
-      final FieldVector fv = Data.importVector(alloc, array, schema, null);
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
+        final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
+      StaticJniApi.get().baseVectorToArrow(vector, cSchema, cArray);
+      final FieldVector fv = Data.importVector(alloc, cArray, cSchema, null);
       return fv;
     }
   }
 
+  public static Table toArrowTable(BufferAllocator alloc, RowVector vector) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
+        final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
+      StaticJniApi.get().baseVectorToArrow(vector, cSchema, cArray);
+      final VectorSchemaRoot vsr = Data.importVectorSchemaRoot(alloc, cArray, cSchema, null);
+      return new Table(vsr);
+    }
+  }
+
   public BaseVector fromArrowVector(BufferAllocator alloc, FieldVector arrowVector) {
-    try (final ArrowSchema cSchema1 = ArrowSchema.allocateNew(alloc);
-        final ArrowArray cArray1 = ArrowArray.allocateNew(alloc)) {
-      Data.exportVector(alloc, arrowVector, null, cArray1, cSchema1);
-      final BaseVector imported = jniApi.arrowToBaseVector(cSchema1, cArray1);
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
+        final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
+      Data.exportVector(alloc, arrowVector, null, cArray, cSchema);
+      final BaseVector imported = jniApi.arrowToBaseVector(cSchema, cArray);
       return imported;
+    }
+  }
+
+  public RowVector fromArrowTable(BufferAllocator alloc, Table table) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
+        final ArrowArray cArray = ArrowArray.allocateNew(alloc);
+        final VectorSchemaRoot vsr = table.toVectorSchemaRoot()) {
+      Data.exportVectorSchemaRoot(alloc, vsr, null, cArray, cSchema);
+      final BaseVector imported = jniApi.arrowToBaseVector(cSchema, cArray);
+      Preconditions.checkState(imported instanceof RowVector,
+          "Expected RowVector, got %s", imported.getClass().getName());
+      return (RowVector) imported;
     }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVector.java
@@ -1,7 +1,13 @@
 package io.github.zhztheplayer.velox4j.data;
 
+import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.jni.CppObject;
+import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
+import io.github.zhztheplayer.velox4j.type.Type;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
 
 public class BaseVector implements CppObject {
   private final JniApi jniApi;
@@ -12,12 +18,46 @@ public class BaseVector implements CppObject {
     this.id = id;
   }
 
-  public JniApi jniApi() {
-    return jniApi;
-  }
-
   @Override
   public long id() {
     return id;
+  }
+
+  public Type getType() {
+    return StaticJniApi.get().baseVectorGetType(this);
+  }
+
+  public VectorEncoding getEncoding() {
+    return StaticJniApi.get().baseVectorGetEncoding(this);
+  }
+
+  public int getSize() {
+    return StaticJniApi.get().baseVectorGetSize(this);
+  }
+
+  public BaseVector wrapInConstant(int length, int index) {
+    return jniApi.baseVectorWrapInConstant(this, length, index);
+  }
+
+  @Deprecated
+  public RowVector asRowVector() {
+    return jniApi.baseVectorAsRowVector(this);
+  }
+
+  public String serialize() {
+    return BaseVectors.serializeOne(this);
+  }
+
+  public String toString(BufferAllocator alloc) {
+    try (final FieldVector fv = Arrow.toArrowVector(alloc, this)) {
+      return fv.toString();
+    }
+  }
+
+  @Override
+  public String toString() {
+    try (final BufferAllocator alloc = new RootAllocator()) {
+      return toString(alloc);
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
@@ -1,14 +1,8 @@
 package io.github.zhztheplayer.velox4j.data;
 
 import com.google.common.base.Preconditions;
-import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
-import io.github.zhztheplayer.velox4j.type.Type;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.table.Table;
 
 import java.util.List;
 
@@ -19,44 +13,22 @@ public class BaseVectors {
     this.jniApi = jniApi;
   }
 
-  public static String serialize(List<? extends BaseVector> vectors) {
-    return StaticJniApi.get().baseVectorSerialize(vectors);
-  }
-
-  public static String serialize(BaseVector vector) {
+  public static String serializeOne(BaseVector vector) {
     return StaticJniApi.get().baseVectorSerialize(List.of(vector));
   }
 
-  public BaseVector deserialize(String serialized) {
+  public BaseVector deserializeOne(String serialized) {
     final List<BaseVector> vectors = jniApi.baseVectorDeserialize(serialized);
     Preconditions.checkState(vectors.size() == 1,
         "Expected one vector, but got %s", vectors.size());
     return vectors.get(0);
   }
 
-  public static Type getType(BaseVector vector) {
-    return StaticJniApi.get().baseVectorGetType(vector);
+  public static String serializeAll(List<? extends BaseVector> vectors) {
+    return StaticJniApi.get().baseVectorSerialize(vectors);
   }
 
-  public static int getSize(BaseVector vector) {
-    return StaticJniApi.get().baseVectorGetSize(vector);
-  }
-
-  public static BaseVector wrapInConstant(BaseVector vector, int length, int index) {
-    return vector.jniApi().baseVectorWrapInConstant(vector, length, index);
-  }
-
-  public static VectorEncoding getEncoding(BaseVector vector) {
-    return StaticJniApi.get().baseVectorGetEncoding(vector);
-  }
-
-  public static RowVector asRowVector(BaseVector vector) {
-    return vector.jniApi().baseVectorAsRowVector(vector);
-  }
-
-  public static String toString(BufferAllocator alloc, BaseVector vector) {
-    try (final FieldVector fv = Arrow.toArrowVector(alloc, vector)) {
-      return fv.toString();
-    }
+  public List<BaseVector> deserializeAll(String serialized) {
+    return jniApi.baseVectorDeserialize(serialized);
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
@@ -8,7 +8,7 @@ import org.apache.arrow.vector.table.Table;
 
 public class RowVector extends BaseVector {
   protected RowVector(JniApi jniApi, long id) {
-    super(jniApi, id);
+    super(jniApi, id, VectorEncoding.ROW);
   }
 
   @Override

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
@@ -7,7 +7,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.table.Table;
 
 public class RowVector extends BaseVector {
-  public RowVector(JniApi jniApi, long id) {
+  protected RowVector(JniApi jniApi, long id) {
     super(jniApi, id);
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
@@ -1,9 +1,21 @@
 package io.github.zhztheplayer.velox4j.data;
 
+import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.table.Table;
 
 public class RowVector extends BaseVector {
   public RowVector(JniApi jniApi, long id) {
     super(jniApi, id);
+  }
+
+  @Override
+  public String toString(BufferAllocator alloc) {
+    try (final Table t = Arrow.toArrowTable(alloc, this);
+        final VectorSchemaRoot vsr = t.toVectorSchemaRoot()) {
+      return vsr.contentToTSVString();
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/RowVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/RowVectors.java
@@ -15,10 +15,4 @@ public class RowVectors {
   public RowVectors(JniApi jniApi) {
     this.jniApi = jniApi;
   }
-
-  public static String toString(BufferAllocator alloc, RowVector rv) {
-    try (final Table t = Arrow.toArrowTable(alloc, rv); final VectorSchemaRoot vsr = t.toVectorSchemaRoot()) {
-      return vsr.contentToTSVString();
-    }
-  }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVector.java
@@ -2,6 +2,7 @@ package io.github.zhztheplayer.velox4j.data;
 
 import io.github.zhztheplayer.velox4j.jni.CppObject;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
+import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
 
 public class SelectivityVector implements CppObject {
   private final long id;
@@ -13,5 +14,9 @@ public class SelectivityVector implements CppObject {
   @Override
   public long id() {
     return id;
+  }
+
+  public boolean isValid(int idx) {
+    return StaticJniApi.get().selectivityVectorIsValid(this, idx);
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/SelectivityVectors.java
@@ -13,8 +13,4 @@ public class SelectivityVectors {
   public SelectivityVector create(int length) {
     return jniApi.createSelectivityVector(length);
   }
-
-  public static boolean isValid(SelectivityVector vector, int idx) {
-    return StaticJniApi.get().selectivityVectorIsValid(vector, idx);
-  }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/ConstantTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/ConstantTypedExpr.java
@@ -27,13 +27,13 @@ public class ConstantTypedExpr extends TypedExpr {
 
   public static ConstantTypedExpr create(BaseVector vector) {
     final BaseVector constVector;
-    if (BaseVectors.getEncoding(vector) == VectorEncoding.CONSTANT) {
+    if (vector.getEncoding() == VectorEncoding.CONSTANT) {
       constVector = vector;
     } else {
-      constVector = BaseVectors.wrapInConstant(vector, 1, 0);
+      constVector = vector.wrapInConstant(1, 0);
     }
-    final String serialized = BaseVectors.serialize(constVector);
-    final Type type = BaseVectors.getType(vector);
+    final String serialized = BaseVectors.serializeOne(constVector);
+    final Type type = vector.getType();
     return new ConstantTypedExpr(type, null, serialized);
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -42,7 +42,7 @@ public final class JniApi {
   }
 
   public RowVector upIteratorNext(UpIterator itr) {
-    return rowVectorWrap(jni.upIteratorNext(itr.id()));
+    return baseVectorWrap(jni.upIteratorNext(itr.id())).asRowVector();
   }
 
   public ExternalStream newExternalStream(DownIterator itr) {
@@ -53,18 +53,7 @@ public final class JniApi {
     // TODO Add JNI API `isRowVector` for performance.
     final VectorEncoding encoding = VectorEncoding.valueOf(
         StaticJniWrapper.get().baseVectorGetEncoding(id));
-    if (encoding == VectorEncoding.ROW) {
-      return new RowVector(this, id);
-    }
-    return new BaseVector(this, id);
-  }
-
-  private RowVector rowVectorWrap(long id) {
-    final BaseVector vector = baseVectorWrap(id);
-    if (vector instanceof RowVector) {
-      return ((RowVector) vector);
-    }
-    throw new VeloxException("Expected RowVector, got " + vector.getClass().getName());
+    return BaseVector.wrap(this, id, encoding);
   }
 
   public BaseVector arrowToBaseVector(ArrowSchema schema, ArrowArray array) {
@@ -79,10 +68,6 @@ public final class JniApi {
 
   public BaseVector baseVectorWrapInConstant(BaseVector vector, int length, int index) {
     return baseVectorWrap(jni.baseVectorWrapInConstant(vector.id(), length, index));
-  }
-
-  public RowVector baseVectorAsRowVector(BaseVector vector) {
-    return rowVectorWrap(jni.baseVectorNewRef(vector.id()));
   }
 
   public SelectivityVector createSelectivityVector(int length) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -6,7 +6,6 @@ import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.data.SelectivityVector;
 import io.github.zhztheplayer.velox4j.data.VectorEncoding;
-import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.eval.Evaluator;
 import io.github.zhztheplayer.velox4j.iterator.DownIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -50,7 +50,6 @@ public final class JniApi {
   }
 
   private BaseVector baseVectorWrap(long id) {
-    // TODO Add JNI API `isRowVector` for performance.
     final VectorEncoding encoding = VectorEncoding.valueOf(
         StaticJniWrapper.get().baseVectorGetEncoding(id));
     return BaseVector.wrap(this, id, encoding);

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -49,12 +49,6 @@ public final class JniApi {
     return new ExternalStream(jni.newExternalStream(itr));
   }
 
-  private BaseVector baseVectorWrap(long id) {
-    final VectorEncoding encoding = VectorEncoding.valueOf(
-        StaticJniWrapper.get().baseVectorGetEncoding(id));
-    return BaseVector.wrap(this, id, encoding);
-  }
-
   public BaseVector arrowToBaseVector(ArrowSchema schema, ArrowArray array) {
     return baseVectorWrap(jni.arrowToBaseVector(schema.memoryAddress(), array.memoryAddress()));
   }
@@ -81,5 +75,11 @@ public final class JniApi {
   @VisibleForTesting
   public UpIterator createUpIteratorWithExternalStream(ExternalStream es) {
     return new UpIterator(this, jni.createUpIteratorWithExternalStream(es.id()));
+  }
+
+  private BaseVector baseVectorWrap(long id) {
+    final VectorEncoding encoding = VectorEncoding.valueOf(
+        StaticJniWrapper.get().baseVectorGetEncoding(id));
+    return BaseVector.wrap(this, id, encoding);
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -49,7 +49,6 @@ final class JniWrapper {
   native long arrowToBaseVector(long cSchema, long cArray);
   native long[] baseVectorDeserialize(String serialized);
   native long baseVectorWrapInConstant(long id, int length, int index);
-  native long baseVectorNewRef(long id);
   native long createSelectivityVector(int length);
 
   // For test.

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ValuesNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ValuesNode.java
@@ -27,7 +27,7 @@ public class ValuesNode extends PlanNode {
 
   public static ValuesNode create(String id, List<RowVector> vectors, boolean parallelizable,
       int repeatTimes) {
-    return new ValuesNode(id, BaseVectors.serialize(vectors), parallelizable, repeatTimes);
+    return new ValuesNode(id, BaseVectors.serializeAll(vectors), parallelizable, repeatTimes);
   }
 
   @JsonGetter("data")

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
@@ -30,7 +30,7 @@ public class SelectivityVectorTest {
     final int length = 10;
     final SelectivityVector sv = session.selectivityVectorOps().create(length);
     for (int i = 0; i < length; i++) {
-      Assert.assertTrue(SelectivityVectors.isValid(sv, i));
+      Assert.assertTrue(sv.isValid(i));
     }
     session.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluatorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluatorTest.java
@@ -43,7 +43,7 @@ public class EvaluatorTest {
   public void testFieldAccess() {
     final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = SerdeTests.newSampleRowVector(session);
-    final int size = BaseVectors.getSize(input);
+    final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
     final Evaluation expr = new Evaluation(
         FieldAccessTypedExpr.create(new BigIntType(), "c0"),
@@ -52,7 +52,7 @@ public class EvaluatorTest {
     );
     final Evaluator evaluator = session.evaluationOps().createEvaluator(expr);
     final BaseVector out = evaluator.eval(sv, input);
-    final String outString = BaseVectors.toString(new RootAllocator(), out);
+    final String outString = out.toString();
     Assert.assertEquals(
         ResourceTests.readResourceAsString("eval-output/field-access-1.txt"),
         outString);
@@ -63,19 +63,18 @@ public class EvaluatorTest {
   public void testMultipleEvalCalls() {
     final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = SerdeTests.newSampleRowVector(session);
-    final int size = BaseVectors.getSize(input);
+    final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
     final Evaluation expr = new Evaluation(
         FieldAccessTypedExpr.create(new BigIntType(), "c0"),
         Config.empty(),
         ConnectorConfig.empty()
     );
-    final BufferAllocator alloc = new RootAllocator();
     final Evaluator evaluator = session.evaluationOps().createEvaluator(expr);
     final String expected = ResourceTests.readResourceAsString("eval-output/field-access-1.txt");
     for (int i = 0; i < 10; i++) {
       final BaseVector out = evaluator.eval(sv, input);
-      final String outString = BaseVectors.toString(alloc, out);
+      final String outString = out.toString();
       Assert.assertEquals(expected, outString);
     }
     session.close();
@@ -85,7 +84,7 @@ public class EvaluatorTest {
   public void testMultiply() {
     final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = SerdeTests.newSampleRowVector(session);
-    final int size = BaseVectors.getSize(input);
+    final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
     final Evaluation expr = new Evaluation(
         new CallTypedExpr(new BigIntType(), List.of(
@@ -97,7 +96,7 @@ public class EvaluatorTest {
     );
     final Evaluator evaluator = session.evaluationOps().createEvaluator(expr);
     final BaseVector out = evaluator.eval(sv, input);
-    final String outString = BaseVectors.toString(new RootAllocator(), out);
+    final String outString = out.toString();
     Assert.assertEquals(
         ResourceTests.readResourceAsString("eval-output/multiply-1.txt"),
         outString);

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -183,7 +183,6 @@ public class JniApiTest {
     Assert.assertEquals(serialized, serializedImported);
     arrowVector.close();
     session.close();
-    ;
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
@@ -215,7 +215,7 @@ public final class SerdeTests {
 
   public static RowVector newSampleRowVector(Session session) {
     final String serialized = ResourceTests.readResourceAsString("vector/rowvector-1.b64");
-    final BaseVector deserialized = session.baseVectorOps().deserialize(serialized);
+    final BaseVector deserialized = session.baseVectorOps().deserializeOne(serialized);
     return ((RowVector) deserialized);
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
@@ -216,7 +216,7 @@ public final class SerdeTests {
   public static RowVector newSampleRowVector(Session session) {
     final String serialized = ResourceTests.readResourceAsString("vector/rowvector-1.b64");
     final BaseVector deserialized = session.baseVectorOps().deserializeOne(serialized);
-    return ((RowVector) deserialized);
+    return deserialized.asRowVector();
   }
 
   public static class ObjectAndJson<T> {

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/UpIteratorTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/UpIteratorTests.java
@@ -2,7 +2,6 @@ package io.github.zhztheplayer.velox4j.test;
 
 import io.github.zhztheplayer.velox4j.collection.Streams;
 import io.github.zhztheplayer.velox4j.data.RowVector;
-import io.github.zhztheplayer.velox4j.data.RowVectors;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Assert;
@@ -60,7 +59,7 @@ public final class UpIteratorTests {
       return assertRowVector(i, new Consumer<RowVector>() {
         @Override
         public void accept(RowVector vector) {
-          Assert.assertEquals(expected, RowVectors.toString(alloc, vector));
+          Assert.assertEquals(expected, vector.toString(alloc));
         }
       });
     }


### PR DESCRIPTION
Some static APIs can be moved to associate objects as member methods. This makes invocations more convenient. 

In addition, do some code cleanups against RowVector / BaseVector API in this patch.