### PR TITLE
Preserve task drivers to avoid non-loaded lazy vector crashes the process

### DIFF
--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -174,6 +174,14 @@ jlong baseVectorSlice(
   JNI_METHOD_END(-1)
 }
 
+jlong baseVectorLoadedVector(JNIEnv* env, jobject javaThis, jlong vid) {
+  JNI_METHOD_START
+  auto vector = ObjectStore::retrieve<BaseVector>(vid);
+  auto loadedVector = BaseVector::loadedVectorShared(vector);
+  return sessionOf(env, javaThis)->objectStore()->save(loadedVector);
+  JNI_METHOD_END(-1)
+}
+
 jlong createSelectivityVector(JNIEnv* env, jobject javaThis, jint length) {
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
@@ -296,6 +304,12 @@ void JniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       kTypeInt,
       kTypeInt,
+      nullptr);
+  addNativeMethod(
+      "baseVectorLoadedVector",
+      (void*)baseVectorLoadedVector,
+      kTypeLong,
+      kTypeLong,
       nullptr);
   addNativeMethod(
       "createSelectivityVector",

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -140,7 +140,7 @@ class Out : public UpIterator {
       // destroyed together with the drivers themselves in the last call to
       // Task::next (see
       // https://github.com/facebookincubator/velox/blob/4adec182144e23d7c7d6422e0090d5b59eb32b86/velox/exec/Driver.cpp#L727C13-L727C18),
-      // so if a lazy vector is not loaded while the scan is moved, a meaning
+      // so if a lazy vector is not loaded while the scan is drained, a meaning
       // error
       // (https://github.com/facebookincubator/velox/blob/7af0fce2c27424fbdec1974d96bb1a6d1296419d/velox/dwio/common/ColumnLoader.cpp#L32-L35)
       // can be thrown when the vector is being loaded rather than just crashing

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVector.java
@@ -59,6 +59,10 @@ public class BaseVector implements CppObject {
     StaticJniApi.get().baseVectorAppend(this, toAppend);
   }
 
+  public BaseVector loadedVector() {
+    return jniApi.loadedVector(this);
+  }
+
   public String serialize() {
     return BaseVectors.serializeOne(this);
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -82,6 +82,10 @@ public final class JniApi {
     return baseVectorWrap(jni.baseVectorSlice(vector.id(), offset, length));
   }
 
+  public BaseVector loadedVector(BaseVector vector) {
+    return baseVectorWrap(jni.baseVectorLoadedVector(vector.id()));
+  }
+
   public SelectivityVector createSelectivityVector(int length) {
     return new SelectivityVector(jni.createSelectivityVector(length));
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -52,6 +52,7 @@ final class JniWrapper {
   native long[] baseVectorDeserialize(String serialized);
   native long baseVectorWrapInConstant(long id, int length, int index);
   native long baseVectorSlice(long id, int offset, int length);
+  native long baseVectorLoadedVector(long id);
   native long createSelectivityVector(int length);
 
   // For test.

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -32,17 +32,11 @@ public class StaticJniWrapper {
 
   // For BaseVector / RowVector / SelectivityVector.
   native void baseVectorToArrow(long rvAddress, long cSchema, long cArray);
-
   native String baseVectorSerialize(long[] id);
-
   native String baseVectorGetType(long id);
-
   native int baseVectorGetSize(long id);
-
   native String baseVectorGetEncoding(long id);
-
   native void baseVectorAppend(long id, long toAppendId);
-
   native boolean selectivityVectorIsValid(long id, int idx);
 
   // For test.

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -1,7 +1,6 @@
 package io.github.zhztheplayer.velox4j.jni;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 
 public class StaticJniWrapper {
@@ -11,7 +10,8 @@ public class StaticJniWrapper {
     return INSTANCE;
   }
 
-  private StaticJniWrapper() {}
+  private StaticJniWrapper() {
+  }
 
   // Global initialization.
   native void initialize(String globalConfJson);
@@ -21,6 +21,7 @@ public class StaticJniWrapper {
 
   // Lifecycle.
   native long createSession(long memoryManagerId);
+
   native void releaseCppObject(long objectId);
 
   // For UpIterator.
@@ -31,11 +32,17 @@ public class StaticJniWrapper {
 
   // For BaseVector / RowVector / SelectivityVector.
   native void baseVectorToArrow(long rvAddress, long cSchema, long cArray);
+
   native String baseVectorSerialize(long[] id);
+
   native String baseVectorGetType(long id);
+
   native int baseVectorGetSize(long id);
+
   native String baseVectorGetEncoding(long id);
+
   native void baseVectorAppend(long id, long toAppendId);
+
   native boolean selectivityVectorIsValid(long id, int idx);
 
   // For test.

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -21,7 +21,6 @@ public class StaticJniWrapper {
 
   // Lifecycle.
   native long createSession(long memoryManagerId);
-
   native void releaseCppObject(long objectId);
 
   // For UpIterator.

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -3,6 +3,7 @@ package io.github.zhztheplayer.velox4j.query;
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
+import io.github.zhztheplayer.velox4j.collection.Streams;
 import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.config.ConnectorConfig;
 import io.github.zhztheplayer.velox4j.connector.Assignment;
@@ -14,6 +15,7 @@ import io.github.zhztheplayer.velox4j.connector.FileFormat;
 import io.github.zhztheplayer.velox4j.connector.HiveColumnHandle;
 import io.github.zhztheplayer.velox4j.connector.HiveConnectorSplit;
 import io.github.zhztheplayer.velox4j.connector.HiveTableHandle;
+import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
@@ -44,6 +46,7 @@ import io.github.zhztheplayer.velox4j.type.Type;
 import io.github.zhztheplayer.velox4j.type.VarCharType;
 import io.github.zhztheplayer.velox4j.variant.BigIntValue;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -53,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.stream.Collectors;
 
 public class QueryTest {
   private static MemoryManager memoryManager;
@@ -102,6 +106,33 @@ public class QueryTest {
         .assertNumRowVectors(1)
         .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-scan-region.tsv"))
         .run();
+    session.close();
+  }
+
+  @Test
+  public void testHiveScanCollectMultipleRowVectors() {
+    final Session session = Velox4j.newSession(memoryManager);
+    final File file = TpchTests.Table.NATION.file();
+    final RowType outputType = TpchTests.Table.NATION.schema();
+    final TableScanNode scanNode = newSampleScanNode("id-1", outputType);
+    final List<BoundSplit> splits = List.of(
+        newSampleSplit(scanNode, file)
+    );
+    final int maxOutputBatchRows = 7;
+    final Query query = new Query(scanNode, splits, Config.create(
+        Map.of("max_output_batch_rows", String.format("%d", maxOutputBatchRows))),
+        ConnectorConfig.empty());
+    final UpIterator itr = session.queryOps().execute(query);
+    final List<RowVector> allRvs = Streams.fromIterator(itr).collect(Collectors.toList());
+    Assert.assertTrue(allRvs.size() > 1);
+    for (RowVector rv : allRvs) {
+      Assert.assertTrue(rv.getSize() <= maxOutputBatchRows);
+    }
+    final RowVector appended = session.baseVectorOps().createEmpty(allRvs.get(0).getType()).asRowVector();
+    for (RowVector rv : allRvs) {
+      appended.append(rv);
+    }
+    Assert.assertEquals(ResourceTests.readResourceAsString("query-output/tpch-scan-nation.tsv"), appended.toString());
     session.close();
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -15,6 +15,7 @@ import io.github.zhztheplayer.velox4j.connector.FileFormat;
 import io.github.zhztheplayer.velox4j.connector.HiveColumnHandle;
 import io.github.zhztheplayer.velox4j.connector.HiveConnectorSplit;
 import io.github.zhztheplayer.velox4j.connector.HiveTableHandle;
+import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
@@ -123,7 +124,9 @@ public class QueryTest {
         Map.of("max_output_batch_rows", String.format("%d", maxOutputBatchRows))),
         ConnectorConfig.empty());
     final UpIterator itr = session.queryOps().execute(query);
-    final List<RowVector> allRvs = Streams.fromIterator(itr).collect(Collectors.toList());
+    final List<RowVector> allRvs = Streams.fromIterator(itr)
+        .map(v -> v.loadedVector().asRowVector())
+        .collect(Collectors.toList());
     Assert.assertTrue(allRvs.size() > 1);
     for (RowVector rv : allRvs) {
       Assert.assertTrue(rv.getSize() <= maxOutputBatchRows);


### PR DESCRIPTION
Turns `pure virtual function call` crash to a [meaningful error](https://github.com/facebookincubator/velox/blob/7af0fce2c27424fbdec1974d96bb1a6d1296419d/velox/dwio/common/ColumnLoader.cpp#L32-L35) while a lazy vector is loaded after task is drained.