### PR TITLE
Enable `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` to harden JSON deserialization checks

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerUnsafe.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerUnsafe.java
@@ -1,0 +1,13 @@
+package com.fasterxml.jackson.databind.deser;
+
+import java.util.Set;
+
+public final class BeanDeserializerUnsafe {
+  public static Set<String> getIgnorableProps(BeanDeserializer beanDeserializer) {
+    return beanDeserializer._ignorableProps;
+  }
+
+  public static Set<String> getIncludableProps(BeanDeserializer beanDeserializer) {
+    return beanDeserializer._includableProps;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/CallTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/CallTypedExpr.java
@@ -11,8 +11,11 @@ public class CallTypedExpr extends TypedExpr {
   private final String functionName;
 
   @JsonCreator
-  public CallTypedExpr(@JsonProperty("type") Type returnType,
-      @JsonProperty("inputs") List<TypedExpr> inputs, @JsonProperty("functionName") String functionName) {
+  public CallTypedExpr(
+      @JsonProperty("type") Type returnType,
+      @JsonProperty("inputs") List<TypedExpr> inputs,
+      @JsonProperty("functionName") String functionName
+  ) {
     super(returnType, inputs);
     this.functionName = functionName;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
@@ -51,7 +51,7 @@ public class PolymorphicDeserializer {
         return deserializeWithRegistry(p, ctxt, nextRegistry, objectNode);
       }
       if (registry.isClass(value)) {
-        Class<?> clazz = registry.getClass(value);
+        final Class<?> clazz = registry.getClass(value);
         try {
           return p.getCodec().treeToValue(objectNode, clazz);
         } catch (JsonProcessingException e) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/Serde.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/Serde.java
@@ -28,7 +28,7 @@ public final class Serde {
     jsonMapper.disable(MapperFeature.AUTO_DETECT_GETTERS);
     jsonMapper.disable(MapperFeature.AUTO_DETECT_SETTERS);
     jsonMapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
-    jsonMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    jsonMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     jsonMapper.disable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
     jsonMapper.addModule(new Jdk8Module());
     return jsonMapper.build();

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/Serde.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/Serde.java
@@ -39,7 +39,7 @@ public final class Serde {
     JSON.registerModule(new SimpleModule().setSerializerModifier(new PolymorphicSerializer.Modifier(baseClass)));
   }
 
-  public static ObjectMapper jsonMapper() {
+  static ObjectMapper jsonMapper() {
     return JSON;
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/SerdeRegistryFactory.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/SerdeRegistryFactory.java
@@ -11,10 +11,23 @@ public class SerdeRegistryFactory {
   public static SerdeRegistryFactory createForBaseClass(Class<? extends NativeBean> clazz) {
     return INSTANCES.compute(clazz, (k, v) -> {
       if (v != null) {
-        throw new VeloxException("SerdeRegistryFactory already exists for " + clazz);
+        throw new VeloxException("SerdeRegistryFactory already exists for " + k);
       }
+      checkClass(k, INSTANCES.keySet());
       return new SerdeRegistryFactory(Collections.emptyList());
     });
+  }
+
+  private static void checkClass(Class<? extends NativeBean> clazz, Set<Class<? extends NativeBean>> others) {
+    // The class to register should not be assignable from / to each other.
+    for (Class<? extends NativeBean> other : others) {
+      if (clazz.isAssignableFrom(other)) {
+        throw new VeloxException(String.format("Class %s is not register-able because it is assignable from %s", clazz, other));
+      }
+      if (other.isAssignableFrom(clazz)) {
+        throw new VeloxException(String.format("Class %s is not register-able because it is assignable to %s", clazz, other));
+      }
+    }
   }
 
   public static SerdeRegistryFactory getForBaseClass(Class<? extends NativeBean> clazz) {


### PR DESCRIPTION
With this change, Velox4j's serde will refuse to deserialize JSON object that has known fields. For example:

```json
{
  "name" : "Type",
  "type" : "BOOLEAN"
}
```

This will be deserialized to [BooleanType](https://github.com/velox4j/velox4j/blob/85bd6a3ad78f37d7b45f7cbecf76d65aa1971130/src/main/java/io/github/zhztheplayer/velox4j/type/BooleanType.java#L3).


```json
{
  "name" : "Type",
  "type" : "BOOLEAN",
  "known-field" : "known-value"
}
```

This will cause Velox4j to throw.

While this change is landed, whenever Velox adds a new field to a Velox4j-supported JSON bean with a default serialized value, Velox4j's UT will detect that change by reporting a failure. So we can easily track on Velox serde code changes and do follow-ups fast.