### PR TITLE
Use bundled folly when building Velox

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -33,6 +33,7 @@ include(UseJava)
 
 # Set Velox options.
 set(VELOX_DEPENDENCY_SOURCE AUTO)
+set(folly_SOURCE BUNDLED) # Use velox-bundled folly because we have a custom patch for folly setup.
 set(VELOX_ENABLE_CCACHE ON)
 set(VELOX_MONO_LIBRARY ON)
 set(VELOX_BUILD_SHARED ON)


### PR DESCRIPTION
To make sure the patch added in https://github.com/velox4j/velox4j/pull/73 always takes effect.