### PR TITLE
Update README.md to skip gpg sign for user build

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ NOTE:
 ## Build From Source
 
 ```bash
-mvn clean install
+mvn clean install -Dgpg.skip
 ```
 
 ## Get Started


### PR DESCRIPTION
gpg plugin  is only used for deployment. User could skip the sign step.