### PR TITLE
Add test coverage for ConstantTypedExpr's constructors

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/ConstantTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/ConstantTypedExpr.java
@@ -3,6 +3,7 @@ package io.github.zhztheplayer.velox4j.expression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.BaseVectors;
 import io.github.zhztheplayer.velox4j.data.VectorEncoding;
@@ -21,6 +22,8 @@ public class ConstantTypedExpr extends TypedExpr {
       @JsonProperty("value") Variant value,
       @JsonProperty("valueVector") String serializedVector) {
     super(returnType, Collections.emptyList());
+    Preconditions.checkArgument((value == null) != (serializedVector == null),
+        "Either a variant value or a serialized value vector should be provided when creating ConstantTypedExpr");
     this.value = value;
     this.serializedVector = serializedVector;
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
@@ -2,6 +2,7 @@ package io.github.zhztheplayer.velox4j.serde;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
+import io.github.zhztheplayer.velox4j.data.BaseVectors;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.CastTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.ConcatTypedExpr;
@@ -68,6 +69,10 @@ public class TypedExprSerdeTest {
     SerdeTests.testVeloxSerializableRoundTrip(expr1);
     final ConstantTypedExpr expr2 = ConstantTypedExpr.create(new IntegerValue(15));
     SerdeTests.testVeloxSerializableRoundTrip(expr2);
+    final ConstantTypedExpr expr3 = new ConstantTypedExpr(new IntegerType(), null, BaseVectors.serializeOne(intVector.wrapInConstant(1, 0)));
+    SerdeTests.testVeloxSerializableRoundTrip(expr3);
+    final ConstantTypedExpr expr4 = new ConstantTypedExpr(new IntegerType(), new IntegerValue(15), null);
+    SerdeTests.testVeloxSerializableRoundTrip(expr4);
     session.close();
   }
 


### PR DESCRIPTION
More tests since we opened up the constructor of `ConstantTypedExpr` in https://github.com/velox4j/velox4j/pull/80.