### PR TITLE
Non-blocking serial execution

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -60,6 +60,7 @@ CPMAddPackage(
         URL_HASH MD5=${VELOX_SOURCE_URL_MD5}
         PATCHES
         "${VELOX_PATCH_DIR}/0001-fix-Add-a-patch-to-fix-folly-build-on-arm64-Linux.patch"
+        "${VELOX_PATCH_DIR}/0002-feat-Make-Task-next-invocations-non-blocking.patch"
 )
 
 # Import JniHelpers.

--- a/src/main/cpp/cmake/patches/velox/0002-feat-Make-Task-next-invocations-non-blocking.patch
+++ b/src/main/cpp/cmake/patches/velox/0002-feat-Make-Task-next-invocations-non-blocking.patch
@@ -1,0 +1,127 @@
+From f7eae8f578ce82647ee3c901d5c42f25845533c8 Mon Sep 17 00:00:00 2001
+From: Hongze Zhang <hongze.zzz123@gmail.com>
+Date: Sun, 9 Mar 2025 06:51:28 +0000
+Subject: [PATCH] feat: Make Task::next invocations non-blocking
+
+So far a call to Task::next will block until one of the drivers returns a fulfilled future. This design can be simplified to: Task::next returns the union no matter the child futures are fulfilled or not, then let user decide to wait or do other operations, e.g., to feed more input data to Velox pipeline manually to avoid blocking.
+---
+ velox/exec/Task.cpp | 93 ++++++++++++++++++++-------------------------
+ 1 file changed, 41 insertions(+), 52 deletions(-)
+
+diff --git a/velox/exec/Task.cpp b/velox/exec/Task.cpp
+index aa6f0842f..bc5db6a98 100644
+--- a/velox/exec/Task.cpp
++++ b/velox/exec/Task.cpp
+@@ -705,68 +705,57 @@ RowVectorPtr Task::next(ContinueFuture* future) {
+   std::vector<ContinueFuture> futures;
+   futures.resize(numDrivers);
+ 
+-  for (;;) {
+-    int runnableDrivers = 0;
+-    int blockedDrivers = 0;
+-    for (auto i = 0; i < numDrivers; ++i) {
+-      // Holds a reference to driver for access as async task terminate might
+-      // remove drivers from 'drivers_' slot.
+-      auto driver = getDriver(i);
+-      if (driver == nullptr) {
+-        // This driver has finished processing.
+-        continue;
+-      }
++  for (auto i = 0; i < numDrivers; ++i) {
++    // Holds a reference to driver for access as async task terminate might
++    // remove drivers from 'drivers_' slot.
++    auto driver = getDriver(i);
++    if (driver == nullptr) {
++      // This driver has finished processing.
++      continue;
++    }
+ 
+-      if (!futures[i].isReady()) {
+-        // This driver is still blocked.
+-        ++blockedDrivers;
+-        continue;
+-      }
++    if (!futures[i].isReady()) {
++      // This driver is still blocked.
++      continue;
++    }
+ 
+-      ContinueFuture blockFuture = ContinueFuture::makeEmpty();
+-      if (driverBlockingStates_[i]->blocked(&blockFuture)) {
+-        VELOX_CHECK(blockFuture.valid());
+-        futures[i] = std::move(blockFuture);
+-        // This driver is still blocked.
+-        ++blockedDrivers;
+-        continue;
+-      }
+-      ++runnableDrivers;
++    ContinueFuture blockFuture = ContinueFuture::makeEmpty();
++    if (driverBlockingStates_[i]->blocked(&blockFuture)) {
++      VELOX_CHECK(blockFuture.valid());
++      futures[i] = std::move(blockFuture);
++      // This driver is still blocked.
++      continue;
++    }
+ 
+-      ContinueFuture driverFuture = ContinueFuture::makeEmpty();
+-      auto result = driver->next(&driverFuture);
+-      if (result != nullptr) {
+-        VELOX_CHECK(!driverFuture.valid());
+-        return result;
+-      }
++    ContinueFuture driverFuture = ContinueFuture::makeEmpty();
++    auto result = driver->next(&driverFuture);
++    if (result != nullptr) {
++      VELOX_CHECK(!driverFuture.valid());
++      return result;
++    }
+ 
+-      if (driverFuture.valid()) {
+-        driverBlockingStates_[i]->setDriverFuture(driverFuture);
+-      }
++    if (driverFuture.valid()) {
++      driverBlockingStates_[i]->setDriverFuture(driverFuture);
++    }
+ 
+-      if (error()) {
+-        std::rethrow_exception(error());
+-      }
++    if (error()) {
++      std::rethrow_exception(error());
+     }
++  }
+ 
+-    if (runnableDrivers == 0) {
+-      if (blockedDrivers > 0) {
+-        if (future == nullptr) {
+-          VELOX_FAIL(
+-              "Cannot make progress as all remaining drivers are blocked and user are not expected to wait.");
+-        } else {
+-          std::vector<ContinueFuture> notReadyFutures;
+-          for (auto& continueFuture : futures) {
+-            if (!continueFuture.isReady()) {
+-              notReadyFutures.emplace_back(std::move(continueFuture));
+-            }
+-          }
+-          *future = folly::collectAny(std::move(notReadyFutures)).unit();
+-        }
++  if (future == nullptr) {
++    VELOX_FAIL(
++        "Cannot make progress as all remaining drivers are blocked and user are not expected to wait.");
++  } else {
++    std::vector<ContinueFuture> notReadyFutures;
++    for (auto& continueFuture : futures) {
++      if (!continueFuture.isReady()) {
++        notReadyFutures.emplace_back(std::move(continueFuture));
+       }
+-      return nullptr;
+     }
++    *future = folly::collectAny(std::move(notReadyFutures)).unit();
+   }
++  return nullptr;
+ }
+ 
+ void Task::start(uint32_t maxDrivers, uint32_t concurrentSplitGroups) {
+-- 
+2.43.0
+

--- a/src/main/cpp/main/velox4j/connector/ExternalStream.h
+++ b/src/main/cpp/main/velox4j/connector/ExternalStream.h
@@ -46,9 +46,8 @@ class ExternalStream {
   // DTOR.
   virtual ~ExternalStream() = default;
 
-  virtual bool hasNext() = 0;
-
-  virtual facebook::velox::RowVectorPtr next() = 0;
+  virtual std::optional<facebook::velox::RowVectorPtr> read(
+      facebook::velox::ContinueFuture& future) = 0;
 };
 
 class ExternalStreamConnectorSplit
@@ -92,8 +91,9 @@ class ExternalStreamDataSource : public facebook::velox::connector::DataSource {
       const std::shared_ptr<facebook::velox::connector::ConnectorTableHandle>&
           tableHandle);
 
-  void addSplit(std::shared_ptr<facebook::velox::connector::ConnectorSplit>
-                    split) override;
+  void addSplit(
+      std::shared_ptr<facebook::velox::connector::ConnectorSplit> split)
+      override;
 
   std::optional<facebook::velox::RowVectorPtr> next(
       uint64_t size,

--- a/src/main/cpp/main/velox4j/iterator/UpIterator.h
+++ b/src/main/cpp/main/velox4j/iterator/UpIterator.h
@@ -23,6 +23,8 @@ namespace velox4j {
 
 class UpIterator {
  public:
+  enum class State { AVAILABLE = 0, BLOCKED = 1, FINISHED = 2 };
+
   // CTOR.
   UpIterator() = default;
 
@@ -35,7 +37,7 @@ class UpIterator {
   // DTOR.
   virtual ~UpIterator() = default;
 
-  virtual bool hasNext() = 0;
-  virtual facebook::velox::RowVectorPtr next() = 0;
+  virtual State advance() = 0;
+  virtual facebook::velox::RowVectorPtr get() = 0;
 };
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -66,11 +66,11 @@ void releaseCppObject(JNIEnv* env, jobject javaThis, jlong objId) {
   JNI_METHOD_END()
 }
 
-jboolean upIteratorHasNext(JNIEnv* env, jobject javaThis, jlong itrId) {
+jint upIteratorAdvance(JNIEnv* env, jobject javaThis, jlong itrId) {
   JNI_METHOD_START
   auto itr = ObjectStore::retrieve<UpIterator>(itrId);
-  return itr->hasNext();
-  JNI_METHOD_END(false)
+  return static_cast<jint>(itr->advance());
+  JNI_METHOD_END(-1)
 }
 
 jstring variantInferType(JNIEnv* env, jobject javaThis, jstring json) {
@@ -226,9 +226,9 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       nullptr);
   addNativeMethod(
-      "upIteratorHasNext",
-      (void*)upIteratorHasNext,
-      kTypeBool,
+      "upIteratorAdvance",
+      (void*)upIteratorAdvance,
+      kTypeInt,
       kTypeLong,
       nullptr);
   addNativeMethod(
@@ -295,11 +295,7 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       nullptr);
   addNativeMethod(
-      "variantAsJava",
-      (void*)variantAsJava,
-      kTypeString,
-      kTypeLong,
-      nullptr);
+      "variantAsJava", (void*)variantAsJava, kTypeString, kTypeLong, nullptr);
 
   registerNativeMethods(env);
 }

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -29,7 +29,7 @@ ResourceMap<ObjectStore*>& ObjectStore::stores() {
 ObjectStore::~ObjectStore() {
   // destructing in reversed order (the last added object destructed first)
   const std::lock_guard<std::mutex> lock(mtx_);
-  for (auto itr = aliveObjects_.rbegin(); itr != aliveObjects_.rend(); itr++) {
+  for (auto itr = aliveObjects_.rbegin(); itr != aliveObjects_.rend(); ++itr) {
     ResourceHandle handle = *itr;
     store_.erase(handle);
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/CloseableIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/CloseableIterator.java
@@ -1,0 +1,6 @@
+package io.github.zhztheplayer.velox4j.iterator;
+
+import java.util.Iterator;
+
+public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterator.java
@@ -1,26 +1,32 @@
 package io.github.zhztheplayer.velox4j.iterator;
 
-import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.jni.CalledFromNative;
-import io.github.zhztheplayer.velox4j.jni.JniApi;
-import io.github.zhztheplayer.velox4j.jni.CppObject;
 
-import java.util.Iterator;
+public interface DownIterator {
+  enum State {
+    AVAILABLE(0),
+    BLOCKED(1),
+    FINISHED(2);
 
-public class DownIterator {
-  private final Iterator<RowVector> delegated;
+    private final int id;
 
-  public DownIterator(Iterator<RowVector> delegated) {
-    this.delegated = delegated;
+    State(int id) {
+      this.id = id;
+    }
+
+    public int getId() {
+      return id;
+    }
   }
 
   @CalledFromNative
-  public boolean hasNext() {
-    return delegated.hasNext();
+  default int advance() {
+      return advance0().getId();
   }
-
   @CalledFromNative
-  public long next() {
-    return delegated.next().id();
-  }
+  long get();
+  @CalledFromNative
+  void close();
+
+  State advance0();
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterators.java
@@ -1,0 +1,73 @@
+package io.github.zhztheplayer.velox4j.iterator;
+
+import com.google.common.base.Preconditions;
+import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.exception.VeloxException;
+
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class DownIterators {
+  public static DownIterator fromJavaIterator(Iterator<RowVector> itr) {
+    return new FromJavaIterator(itr);
+  }
+
+  public static DownIterator fromQueue(Queue<RowVector> queue) {
+    return new FromQueue(queue);
+  }
+
+  private static class FromJavaIterator implements DownIterator {
+    private final Iterator<RowVector> itr;
+
+    private FromJavaIterator(Iterator<RowVector> itr) {
+      this.itr = itr;
+    }
+
+    @Override
+    public State advance0() {
+      if (!itr.hasNext()) {
+        return State.FINISHED;
+      }
+      return State.AVAILABLE;
+    }
+
+    @Override
+    public long get() {
+      return itr.next().id();
+    }
+
+    @Override
+    public void close() {
+
+    }
+  }
+
+  private static class FromQueue implements DownIterator {
+    private final Queue<RowVector> queue;
+
+    public FromQueue(Queue<RowVector> queue) {
+      this.queue = queue;
+    }
+
+    @Override
+    public State advance0() {
+      if (queue.isEmpty()) {
+        return State.BLOCKED;
+      }
+      return State.AVAILABLE;
+    }
+
+    @Override
+    public long get() {
+      return queue.remove().id();
+    }
+
+    @Override
+    public void close() {
+
+    }
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
@@ -1,13 +1,40 @@
 package io.github.zhztheplayer.velox4j.iterator;
 
+import com.google.common.base.Preconditions;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.jni.CppObject;
 import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
 
-import java.util.Iterator;
+import java.util.HashMap;
+import java.util.Map;
 
-public class UpIterator implements CppObject, Iterator<RowVector> {
+public class UpIterator implements CppObject {
+  private static final Map<Integer, State> ID_LOOKUP = new HashMap<>();
+
+  public enum State {
+    AVAILABLE(0),
+    BLOCKED(1),
+    FINISHED(2);
+
+    public static State get(int id) {
+      Preconditions.checkArgument(ID_LOOKUP.containsKey(id), "ID not found: %d", id);
+      return ID_LOOKUP.get(id);
+    }
+
+    private final int id;
+
+    State(int id) {
+      this.id = id;
+      Preconditions.checkArgument(!ID_LOOKUP.containsKey(id));
+      ID_LOOKUP.put(id, this);
+    }
+
+    public int getId() {
+      return id;
+    }
+  }
+
   private final JniApi jniApi;
   private final long id;
 
@@ -16,14 +43,12 @@ public class UpIterator implements CppObject, Iterator<RowVector> {
     this.id = id;
   }
 
-  @Override
-  public boolean hasNext() {
-    return StaticJniApi.get().upIteratorHasNext(this);
+  public State advance() {
+    return StaticJniApi.get().upIteratorAdvance(this);
   }
 
-  @Override
-  public RowVector next() {
-    return jniApi.upIteratorNext(this);
+  public RowVector get() {
+    return jniApi.upIteratorGet(this);
   }
 
   @Override

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
@@ -1,0 +1,42 @@
+package io.github.zhztheplayer.velox4j.iterator;
+
+import io.github.zhztheplayer.velox4j.data.RowVector;
+
+public final class UpIterators {
+  public static CloseableIterator<RowVector> asJavaIterator(UpIterator upIterator) {
+    return new AsJavaIterator(upIterator);
+  }
+
+  private static class AsJavaIterator implements CloseableIterator<RowVector> {
+    private final UpIterator upIterator;
+
+    private AsJavaIterator(UpIterator upIterator) {
+      this.upIterator = upIterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      while (true) {
+        final UpIterator.State state = upIterator.advance();
+        switch (state) {
+          case BLOCKED:
+            continue;
+          case AVAILABLE:
+            return true;
+          case FINISHED:
+            return false;
+        }
+      }
+    }
+
+    @Override
+    public RowVector next() {
+      return upIterator.get();
+    }
+
+    @Override
+    public void close() throws Exception {
+      upIterator.close();
+    }
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -57,8 +57,8 @@ public final class JniApi {
     return new UpIterator(this, jni.executeQuery(queryJson));
   }
 
-  public RowVector upIteratorNext(UpIterator itr) {
-    return baseVectorWrap(jni.upIteratorNext(itr.id())).asRowVector();
+  public RowVector upIteratorGet(UpIterator itr) {
+    return baseVectorWrap(jni.upIteratorGet(itr.id())).asRowVector();
   }
 
   public ExternalStream newExternalStream(DownIterator itr) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -41,7 +41,7 @@ final class JniWrapper {
   native long executeQuery(String queryJson);
 
   // For UpIterator.
-  native long upIteratorNext(long address);
+  native long upIteratorGet(long id);
 
   // For DownIterator.
   native long newExternalStream(DownIterator itr);

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -49,8 +49,8 @@ public class StaticJniApi {
     jni.releaseCppObject(obj.id());
   }
 
-  public boolean upIteratorHasNext(UpIterator itr) {
-    return jni.upIteratorHasNext(itr.id());
+  public UpIterator.State upIteratorAdvance(UpIterator itr) {
+    return UpIterator.State.get(jni.upIteratorAdvance(itr.id()));
   }
 
   public Type variantInferType(Variant variant) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -23,13 +23,14 @@ public class StaticJniWrapper {
   native void releaseCppObject(long objectId);
 
   // For UpIterator.
-  native boolean upIteratorHasNext(long address);
+  native int upIteratorAdvance(long id);
+  native void upIteratorWait(long id);
 
   // For Variant.
   native String variantInferType(String json);
 
   // For BaseVector / RowVector / SelectivityVector.
-  native void baseVectorToArrow(long rvAddress, long cSchema, long cArray);
+  native void baseVectorToArrow(long rvid, long cSchema, long cArray);
   native String baseVectorSerialize(long[] id);
   native String baseVectorGetType(long id);
   native int baseVectorGetSize(long id);

--- a/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
@@ -2,6 +2,7 @@ package io.github.zhztheplayer.velox4j.arrow;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
+import io.github.zhztheplayer.velox4j.data.BaseVectorTests;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
@@ -34,13 +35,11 @@ public class ArrowTest {
   @Test
   public void testBaseVectorRoundTrip() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
-    final String serialized = input.serialize();
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
     final FieldVector arrowVector = Arrow.toArrowVector(alloc, input);
     final BaseVector imported = session.arrowOps().fromArrowVector(alloc, arrowVector);
-    final String serializedImported = imported.serialize();
-    Assert.assertEquals(serialized, serializedImported);
+    BaseVectorTests.assertEquals(input, imported);
     arrowVector.close();
     session.close();
   }
@@ -48,13 +47,11 @@ public class ArrowTest {
   @Test
   public void testRowVectorRoundTrip() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
-    final String serialized = input.serialize();
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
     final Table arrowTable = Arrow.toArrowTable(alloc, input);
     final RowVector imported = session.arrowOps().fromArrowTable(alloc, arrowTable);
-    final String serializedImported = imported.serialize();
-    Assert.assertEquals(serialized, serializedImported);
+    BaseVectorTests.assertEquals(input, imported);
     arrowTable.close();
     session.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
@@ -59,7 +59,7 @@ public class BaseVectorTest {
   @Test
   public void testToString() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(ResourceTests.readResourceAsString("vector-output/to-string-1.txt"),
         input.toString());
     session.close();
@@ -68,7 +68,7 @@ public class BaseVectorTest {
   @Test
   public void testSlice() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(3, input.getSize());
     final RowVector sliced1 = input.slice(0, 2).asRowVector();
     final RowVector sliced2 = input.slice(2, 1).asRowVector();
@@ -82,8 +82,8 @@ public class BaseVectorTest {
   @Test
   public void testAppend() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input1 = SerdeTests.newSampleRowVector(session);
-    final RowVector input2 = SerdeTests.newSampleRowVector(session);
+    final RowVector input1 = BaseVectorTests.newSampleRowVector(session);
+    final RowVector input2 = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(3, input1.getSize());
     Assert.assertEquals(3, input2.getSize());
     input1.append(input2);

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTests.java
@@ -1,0 +1,48 @@
+package io.github.zhztheplayer.velox4j.data;
+
+import io.github.zhztheplayer.velox4j.serde.Serde;
+import io.github.zhztheplayer.velox4j.session.Session;
+import io.github.zhztheplayer.velox4j.test.ResourceTests;
+import io.github.zhztheplayer.velox4j.type.Type;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.junit.Assert;
+
+import java.util.List;
+
+public final class BaseVectorTests {
+  private BaseVectorTests() {
+
+  }
+
+  public static void assertEquals(BaseVector expected, BaseVector actual) {
+    final Type typeExpected = expected.getType();
+    final Type typeActual = actual.getType();
+    Assert.assertEquals(Serde.toPrettyJson(typeExpected), Serde.toPrettyJson(typeActual));
+    Assert.assertEquals(expected.toString(), actual.toString());
+  }
+
+  public static void assertEquals(List<? extends BaseVector> expected, List<? extends BaseVector> actual) {
+    Assert.assertEquals(expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); i++) {
+      assertEquals(expected.get(i), actual.get(i));
+    }
+  }
+
+  public static BaseVector newSampleIntVector(Session session) {
+    final BufferAllocator alloc = new RootAllocator();
+    final IntVector arrowVector = new IntVector("foo", alloc);
+    arrowVector.setValueCount(1);
+    arrowVector.set(0, 15);
+    final BaseVector baseVector = session.arrowOps().fromArrowVector(alloc, arrowVector);
+    arrowVector.close();
+    return baseVector;
+  }
+
+  public static RowVector newSampleRowVector(Session session) {
+    final String serialized = ResourceTests.readResourceAsString("vector/rowvector-1.b64");
+    final BaseVector deserialized = session.baseVectorOps().deserializeOne(serialized);
+    return deserialized.asRowVector();
+  }
+}

--- a/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
@@ -4,6 +4,7 @@ import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.config.ConnectorConfig;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
+import io.github.zhztheplayer.velox4j.data.BaseVectorTests;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.data.SelectivityVector;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
@@ -39,7 +40,7 @@ public class EvaluationTest {
   @Test
   public void testFieldAccess() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
     final Evaluation expr = new Evaluation(
@@ -59,7 +60,7 @@ public class EvaluationTest {
   @Test
   public void testMultipleEvalCalls() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
     final Evaluation expr = new Evaluation(
@@ -80,7 +81,7 @@ public class EvaluationTest {
   @Test
   public void testMultiply() {
     final Session session = Velox4j.newSession(memoryManager);
-    final RowVector input = SerdeTests.newSampleRowVector(session);
+    final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
     final Evaluation expr = new Evaluation(

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -4,6 +4,7 @@ import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
 import io.github.zhztheplayer.velox4j.connector.CommitStrategy;
+import io.github.zhztheplayer.velox4j.data.BaseVectorTests;
 import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.plan.TableWriteNode;
@@ -68,9 +69,10 @@ public class PlanNodeSerdeTest {
 
   @Test
   public void testValuesNode() {
+    // The case fails in debug build. Should investigate.
     final Session session = Velox4j.newSession(memoryManager);
     final PlanNode values = ValuesNode.create("id-1",
-        List.of(SerdeTests.newSampleRowVector(session)), true, 1);
+        List.of(BaseVectorTests.newSampleRowVector(session)), true, 1);
     SerdeTests.testVeloxSerializableRoundTrip(values);
     session.close();
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
@@ -280,22 +280,6 @@ public final class SerdeTests {
     return new RowType(List.of("foo", "bar"), List.of(new IntegerType(), new IntegerType()));
   }
 
-  public static BaseVector newSampleIntVector(Session session) {
-    final BufferAllocator alloc = new RootAllocator();
-    final IntVector arrowVector = new IntVector("foo", alloc);
-    arrowVector.setValueCount(1);
-    arrowVector.set(0, 15);
-    final BaseVector baseVector = session.arrowOps().fromArrowVector(alloc, arrowVector);
-    arrowVector.close();
-    return baseVector;
-  }
-
-  public static RowVector newSampleRowVector(Session session) {
-    final String serialized = ResourceTests.readResourceAsString("vector/rowvector-1.b64");
-    final BaseVector deserialized = session.baseVectorOps().deserializeOne(serialized);
-    return deserialized.asRowVector();
-  }
-
   public static class ObjectAndJson<T> {
     private final T obj;
     private final String json;

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
@@ -3,6 +3,7 @@ package io.github.zhztheplayer.velox4j.serde;
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.BaseVectors;
+import io.github.zhztheplayer.velox4j.data.BaseVectorTests;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.CastTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.ConcatTypedExpr;
@@ -64,7 +65,7 @@ public class TypedExprSerdeTest {
   @Test
   public void testConstantTypedExpr() {
     final Session session = Velox4j.newSession(memoryManager);
-    final BaseVector intVector = SerdeTests.newSampleIntVector(session);
+    final BaseVector intVector = BaseVectorTests.newSampleIntVector(session);
     final ConstantTypedExpr expr1 = ConstantTypedExpr.create(intVector);
     SerdeTests.testVeloxSerializableRoundTrip(expr1);
     final ConstantTypedExpr expr2 = ConstantTypedExpr.create(new IntegerValue(15));

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/UpIteratorTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/UpIteratorTests.java
@@ -2,7 +2,9 @@ package io.github.zhztheplayer.velox4j.test;
 
 import io.github.zhztheplayer.velox4j.collection.Streams;
 import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.iterator.CloseableIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
+import io.github.zhztheplayer.velox4j.iterator.UpIterators;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Assert;
@@ -21,7 +23,8 @@ public final class UpIteratorTests {
   }
 
   private static List<RowVector> collect(UpIterator itr) {
-    final List<RowVector> vectors = Streams.fromIterator(itr).collect(Collectors.toList());
+    final List<RowVector> vectors = Streams.fromIterator(UpIterators.asJavaIterator(itr))
+        .collect(Collectors.toList());
     return vectors;
   }
 
@@ -31,12 +34,12 @@ public final class UpIteratorTests {
 
   public static class IteratorAssertionBuilder {
     private final RootAllocator alloc = new RootAllocator();
-    private final UpIterator itr;
+    private final CloseableIterator<RowVector> itr;
     private final List<Consumer<Argument>> assertions = new ArrayList<>();
     private final List<Runnable> finalAssertions = new ArrayList<>();
 
     private IteratorAssertionBuilder(UpIterator itr) {
-      this.itr = itr;
+      this.itr = UpIterators.asJavaIterator(itr);
     }
 
     public IteratorAssertionBuilder assertNumRowVectors(int expected) {


### PR DESCRIPTION
Introduce `OutIterator#State` which is returned by `OutIterator#advance`, to distinguish between the "finished" state and "blocked" state of the underlying Velox task.

See the added UTs for more detailed usages and conventions.