### PR TITLE
Allow writing absent `bucketConversion` as null in  JSON

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/HiveConnectorSplit.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/HiveConnectorSplit.java
@@ -101,8 +101,6 @@ public class HiveConnectorSplit extends ConnectorSplit {
   }
 
   @JsonGetter("bucketConversion")
-  // FIXME: https://github.com/facebookincubator/velox/pull/12509
-  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   public Optional<HiveBucketConversion> getBucketConversion() {
     return bucketConversion;
   }


### PR DESCRIPTION
Depends on https://github.com/facebookincubator/velox/pull/12509