### PR TITLE
UT: Avoid single case failure crashes the whole suite

### DIFF
--- a/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
@@ -13,13 +13,11 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.table.Table;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 public class ArrowTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -32,27 +30,33 @@ public class ArrowTest {
     memoryManager.close();
   }
 
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
+  }
+
   @Test
   public void testBaseVectorRoundTrip() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
     final FieldVector arrowVector = Arrow.toArrowVector(alloc, input);
     final BaseVector imported = session.arrowOps().fromArrowVector(alloc, arrowVector);
     BaseVectorTests.assertEquals(input, imported);
     arrowVector.close();
-    session.close();
   }
 
   @Test
   public void testRowVectorRoundTrip() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
     final Table arrowTable = Arrow.toArrowTable(alloc, input);
     final RowVector imported = session.arrowOps().fromArrowTable(alloc, arrowTable);
     BaseVectorTests.assertEquals(input, imported);
     arrowTable.close();
-    session.close();
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
@@ -12,15 +12,13 @@ import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RealType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.Type;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.List;
 
 public class BaseVectorTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -33,19 +31,26 @@ public class BaseVectorTest {
     memoryManager.close();
   }
 
-  @Test
-  public void testCreateEmpty1() {
-    final Session session = Velox4j.newSession(memoryManager);
-    final Type type = new RealType();
-    final BaseVector vector = session.baseVectorOps().createEmpty(type);
-    Assert.assertEquals(Serde.toPrettyJson(type), Serde.toPrettyJson(vector.getType()));
-    Assert.assertEquals(0, vector.getSize());
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
     session.close();
   }
 
   @Test
+  public void testCreateEmpty1() {
+    final Type type = new RealType();
+    final BaseVector vector = session.baseVectorOps().createEmpty(type);
+    Assert.assertEquals(Serde.toPrettyJson(type), Serde.toPrettyJson(vector.getType()));
+    Assert.assertEquals(0, vector.getSize());
+  }
+
+  @Test
   public void testCreateEmpty2() {
-    final Session session = Velox4j.newSession(memoryManager);
     final Type type = new RowType(
         List.of("foo2", "bar2"),
         List.of(new IntegerType(), new IntegerType())
@@ -53,21 +58,17 @@ public class BaseVectorTest {
     final BaseVector vector = session.baseVectorOps().createEmpty(type);
     Assert.assertEquals(Serde.toPrettyJson(type), Serde.toPrettyJson(vector.getType()));
     Assert.assertEquals(0, vector.getSize());
-    session.close();
   }
 
   @Test
   public void testToString() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(ResourceTests.readResourceAsString("vector-output/to-string-1.txt"),
         input.toString());
-    session.close();
   }
 
   @Test
   public void testSlice() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(3, input.getSize());
     final RowVector sliced1 = input.slice(0, 2).asRowVector();
@@ -76,12 +77,10 @@ public class BaseVectorTest {
         sliced1.toString());
     Assert.assertEquals(ResourceTests.readResourceAsString("vector-output/slice-2.txt"),
         sliced2.toString());
-    session.close();
   }
 
   @Test
   public void testAppend() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input1 = BaseVectorTests.newSampleRowVector(session);
     final RowVector input2 = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(3, input1.getSize());
@@ -96,6 +95,5 @@ public class BaseVectorTest {
     Assert.assertEquals(9, input2.getSize());
     Assert.assertEquals(ResourceTests.readResourceAsString("vector-output/append-2.txt"),
         input2.toString());
-    session.close();
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
@@ -5,13 +5,11 @@ import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 public class SelectivityVectorTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -24,14 +22,22 @@ public class SelectivityVectorTest {
     memoryManager.close();
   }
 
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
+  }
+
   @Test
   public void testIsValid() {
-    final Session session = Velox4j.newSession(memoryManager);
     final int length = 10;
     final SelectivityVector sv = session.selectivityVectorOps().create(length);
     for (int i = 0; i < length; i++) {
       Assert.assertTrue(sv.isValid(i));
     }
-    session.close();
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
@@ -11,20 +11,17 @@ import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
-import io.github.zhztheplayer.velox4j.serde.SerdeTests;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.List;
 
 public class EvaluationTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -37,9 +34,18 @@ public class EvaluationTest {
     memoryManager.close();
   }
 
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
+  }
+
   @Test
   public void testFieldAccess() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
@@ -54,12 +60,10 @@ public class EvaluationTest {
     Assert.assertEquals(
         ResourceTests.readResourceAsString("eval-output/field-access-1.txt"),
         outString);
-    session.close();
   }
 
   @Test
   public void testMultipleEvalCalls() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
@@ -75,12 +79,10 @@ public class EvaluationTest {
       final String outString = out.toString();
       Assert.assertEquals(expected, outString);
     }
-    session.close();
   }
 
   @Test
   public void testMultiply() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     final int size = input.getSize();
     final SelectivityVector sv = session.selectivityVectorOps().create(size);
@@ -98,6 +100,5 @@ public class EvaluationTest {
     Assert.assertEquals(
         ResourceTests.readResourceAsString("eval-output/multiply-1.txt"),
         outString);
-    session.close();
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -25,14 +25,13 @@ import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.variant.BooleanValue;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.List;
 
 public class PlanNodeSerdeTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -43,6 +42,16 @@ public class PlanNodeSerdeTest {
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
   }
 
   @Test
@@ -70,11 +79,9 @@ public class PlanNodeSerdeTest {
   @Test
   public void testValuesNode() {
     // The case fails in debug build. Should investigate.
-    final Session session = Velox4j.newSession(memoryManager);
     final PlanNode values = ValuesNode.create("id-1",
         List.of(BaseVectorTests.newSampleRowVector(session)), true, 1);
     SerdeTests.testVeloxSerializableRoundTrip(values);
-    session.close();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
@@ -22,16 +22,14 @@ import io.github.zhztheplayer.velox4j.type.RealType;
 import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.VarCharType;
 import io.github.zhztheplayer.velox4j.variant.IntegerValue;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.Collections;
 import java.util.List;
 
 public class TypedExprSerdeTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -42,6 +40,16 @@ public class TypedExprSerdeTest {
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
   }
 
   @Test
@@ -64,7 +72,6 @@ public class TypedExprSerdeTest {
 
   @Test
   public void testConstantTypedExpr() {
-    final Session session = Velox4j.newSession(memoryManager);
     final BaseVector intVector = BaseVectorTests.newSampleIntVector(session);
     final ConstantTypedExpr expr1 = ConstantTypedExpr.create(intVector);
     SerdeTests.testVeloxSerializableRoundTrip(expr1);
@@ -74,7 +81,6 @@ public class TypedExprSerdeTest {
     SerdeTests.testVeloxSerializableRoundTrip(expr3);
     final ConstantTypedExpr expr4 = new ConstantTypedExpr(new IntegerType(), new IntegerValue(15), null);
     SerdeTests.testVeloxSerializableRoundTrip(expr4);
-    session.close();
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/write/TableWriteTraitsTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/write/TableWriteTraitsTest.java
@@ -9,13 +9,11 @@ import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.RowType;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 public class TableWriteTraitsTest {
   private static MemoryManager memoryManager;
+  private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -26,6 +24,16 @@ public class TableWriteTraitsTest {
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
   }
 
   @Test
@@ -39,7 +47,6 @@ public class TableWriteTraitsTest {
 
   @Test
   public void testOutputTypeWithAggregationNode() {
-    final Session session = Velox4j.newSession(memoryManager);
     final RowType type = session.tableWriteTraitsOps().outputType(
         SerdeTests.newSampleAggregationNode("id-2", "id-1")
     );
@@ -47,6 +54,5 @@ public class TableWriteTraitsTest {
         ResourceTests.readResourceAsString("table-write-traits/output-type-with-aggregation-node-1.json"),
         Serde.toPrettyJson(type)
     );
-    session.close();
   }
 }


### PR DESCRIPTION
Make sure `session.close()` always run to avoid memory leak error and avoid the whole suite be crashed while one case is failing.