### PR TITLE
Exclude explicit dependencies libjvm.so / libjawt.so from the installation to make the Jar file portable for different JDK versions

### DIFF
--- a/src/main/cpp/CMakeLists.txt
+++ b/src/main/cpp/CMakeLists.txt
@@ -70,7 +70,7 @@ set(JNI_HELPERS_SOURCE_URL_MD5 3f168384670e0f21a2e2281f91cfb2e1)
 set(JNI_HELPERS_SOURCE_URL "https://github.com/${JNI_HELPERS_REPO}/archive/${JNI_HELPERS_REF}.zip")
 CPMAddPackage(NAME JniHelpersLib URL ${JNI_HELPERS_SOURCE_URL} URL_HASH MD5=${JNI_HELPERS_SOURCE_URL_MD5})
 target_include_directories(JniHelpers PRIVATE ${JNI_INCLUDE_DIRS})
-target_link_libraries(JniHelpers PRIVATE ${JNI_LIBRARIES})
+target_link_libraries(JniHelpers PRIVATE JNI::JNI)
 
 # Directories of Velox4J.
 set(VELOX4J_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/main)

--- a/src/main/cpp/main/CMakeLists.txt
+++ b/src/main/cpp/main/CMakeLists.txt
@@ -32,7 +32,7 @@ set(VELOX4J_INCLUDES
 set(VELOX4J_DEPENDENCIES
         velox
         JniHelpers
-        ${JNI_LIBRARIES})
+        JNI::JNI)
 
 # The output library.
 add_library(velox4j_shared SHARED ${VELOX4J_SOURCES})


### PR DESCRIPTION
Refer to https://cmake.org/cmake/help/v3.28/module/FindJNI.html

`${JNI_LIBRARIES}` includes libjvm.so / libjawt.so. Explicitly linking libvelox4j.so with the two libraries may cause portability issues. (like crashes on different JDK platforms).

The patch fixes the issue by moving to standardized `JNI::JNI` writing which only add inclusions of  JNI headers to the main target.