### PR TITLE
Separate query execution routine into 2 steps

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -12,6 +12,7 @@ import io.github.zhztheplayer.velox4j.iterator.DownIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.query.Query;
+import io.github.zhztheplayer.velox4j.query.QueryExecutor;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 import io.github.zhztheplayer.velox4j.serializable.ISerializableCo;
@@ -47,14 +48,18 @@ public final class JniApi {
     return baseVectorWrap(jni.evaluatorEval(evaluator.id(), sv.id(), input.id()));
   }
 
-  public UpIterator executeQuery(Query query) {
+  public QueryExecutor createQueryExecutor(Query query) {
     final String queryJson = Serde.toPrettyJson(query);
-    return new UpIterator(this, jni.executeQuery(queryJson));
+    return new QueryExecutor(this, jni.createQueryExecutor(queryJson));
   }
 
   @VisibleForTesting
-  UpIterator executeQuery(String queryJson) {
-    return new UpIterator(this, jni.executeQuery(queryJson));
+  QueryExecutor createQueryExecutor(String queryJson) {
+    return new QueryExecutor(this, jni.createQueryExecutor(queryJson));
+  }
+
+  public UpIterator queryExecutorExecute(QueryExecutor executor) {
+    return new UpIterator(this, jni.queryExecutorExecute(executor.id()));
   }
 
   public RowVector upIteratorGet(UpIterator itr) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -38,7 +38,8 @@ final class JniWrapper {
   native long evaluatorEval(long evaluatorId, long selectivityVectorId, long rvId);
 
   // Plan execution.
-  native long executeQuery(String queryJson);
+  native long createQueryExecutor(String queryJson);
+  native long queryExecutorExecute(long id);
 
   // For UpIterator.
   native long upIteratorGet(long id);

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/Queries.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/Queries.java
@@ -15,4 +15,8 @@ public class Queries {
       return exec.execute();
     }
   }
+
+  public QueryExecutor createQueryExecutor(Query query) {
+    return jniApi.createQueryExecutor(query);
+  }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/Queries.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/Queries.java
@@ -11,6 +11,8 @@ public class Queries {
   }
 
   public UpIterator execute(Query query) {
-    return jniApi.executeQuery(query);
+    try (final QueryExecutor exec = jniApi.createQueryExecutor(query)) {
+      return exec.execute();
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/QueryExecutor.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/QueryExecutor.java
@@ -1,0 +1,24 @@
+package io.github.zhztheplayer.velox4j.query;
+
+import io.github.zhztheplayer.velox4j.iterator.UpIterator;
+import io.github.zhztheplayer.velox4j.jni.CppObject;
+import io.github.zhztheplayer.velox4j.jni.JniApi;
+
+public class QueryExecutor implements CppObject {
+  private final JniApi jniApi;
+  private final long id;
+
+  public QueryExecutor(JniApi jniApi, long id) {
+    this.jniApi = jniApi;
+    this.id = id;
+  }
+
+  @Override
+  public long id() {
+    return id;
+  }
+
+  public UpIterator execute() {
+    return jniApi.queryExecutorExecute(this);
+  }
+}

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -29,6 +29,7 @@ import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterators;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
+import io.github.zhztheplayer.velox4j.query.QueryExecutor;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
@@ -96,7 +97,8 @@ public class JniApiTest {
     final String json = SampleQueryTests.readQueryJson();
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     itr.close();
     session.close();
   }
@@ -106,7 +108,8 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     SampleQueryTests.assertIterator(itr);
     session.close();
     ;
@@ -117,8 +120,9 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr1 = jniApi.executeQuery(json);
-    final UpIterator itr2 = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr1 = queryExecutor.execute();
+    final UpIterator itr2 = queryExecutor.execute();
     SampleQueryTests.assertIterator(itr1);
     SampleQueryTests.assertIterator(itr2);
     session.close();
@@ -143,7 +147,8 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     final RowVector vector = UpIteratorTests.collectSingleVector(itr);
     final List<RowVector> vectors = List.of(vector);
     final String serialized = StaticJniApi.get().baseVectorSerialize(vectors);
@@ -159,7 +164,8 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     final RowVector vector = UpIteratorTests.collectSingleVector(itr);
     final List<RowVector> vectors = List.of(vector, vector);
     final String serialized = StaticJniApi.get().baseVectorSerialize(vectors);
@@ -173,7 +179,8 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     final RowVector vector = UpIteratorTests.collectSingleVector(itr);
     final BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
     final FieldVector arrowVector = Arrow.toArrowVector(alloc, vector);
@@ -195,7 +202,8 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
     final ExternalStream es = jniApi.newExternalStream(down);
     final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);
@@ -208,7 +216,8 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator itr = jniApi.executeQuery(json);
+    final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
+    final UpIterator itr = queryExecutor.execute();
     final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
     final ExternalStream es = jniApi.newExternalStream(down);
     final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -87,6 +87,16 @@ public class QueryTest {
   }
 
   @Test
+  public void testValuesWith2Steps() {
+    final PlanNode values = ValuesNode.create("id-1",
+        List.of(BaseVectorTests.newSampleRowVector(session)), true, 5);
+    final Query query = new Query(values, List.of(), Config.empty(), ConnectorConfig.empty());
+    final QueryExecutor exec = session.queryOps().createQueryExecutor(query);
+    final UpIterator itr = exec.execute();
+    SampleQueryTests.assertIterator(itr, 5);
+  }
+
+  @Test
   public void testValues() {
     final PlanNode values = ValuesNode.create("id-1",
         List.of(BaseVectorTests.newSampleRowVector(session)), true, 5);


### PR DESCRIPTION
This provides an option to user to execute a query within 2 steps:

```java
final QueryExecutor exec = session.queryOps().createQueryExecutor(query);
final UpIterator itr = exec.execute();
```

Compared to existing 1 step fashion:

```java
final UpIterator itr = session.queryOps().execute(query);
```

2-steps fashion can be used in the case of checking for query plan violations to fast-fail.

Both will be available after the patch.