### PR TITLE
Run Ubuntu24 Java UTs in docker

### DIFF
--- a/.github/workflows/scripts/common/setup-ubuntu24.sh
+++ b/.github/workflows/scripts/common/setup-ubuntu24.sh
@@ -5,27 +5,27 @@ set -o pipefail
 set -u
 
 # APT update.
-sudo apt-get update
+apt-get update
 
 # Install essentials.
-sudo apt-get install -y sudo locales wget tar tzdata git ccache ninja-build build-essential
-sudo apt-get install -y llvm-14-dev clang-14 libiberty-dev libdwarf-dev libre2-dev libz-dev
-sudo apt-get install -y liblzo2-dev libzstd-dev libsnappy-dev libdouble-conversion-dev libssl-dev
-sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev curl zip unzip tar pkg-config
-sudo apt-get install -y autoconf-archive bison flex libfl-dev libc-ares-dev libicu-dev
-sudo apt-get install -y libgoogle-glog-dev libbz2-dev libgflags-dev libgmock-dev libevent-dev
-sudo apt-get install -y liblz4-dev libsodium-dev libelf-dev
-sudo apt-get install -y autoconf automake g++ libnuma-dev libtool numactl unzip libdaxctl-dev
-sudo apt-get install -y openjdk-11-jdk
-sudo apt-get install -y maven cmake
-sudo apt-get install -y chrpath patchelf
+apt-get install -y sudo locales wget tar tzdata git ccache ninja-build build-essential
+apt-get install -y llvm-14-dev clang-14 libiberty-dev libdwarf-dev libre2-dev libz-dev
+apt-get install -y liblzo2-dev libzstd-dev libsnappy-dev libdouble-conversion-dev libssl-dev
+apt-get install -y libboost-all-dev libcurl4-openssl-dev curl zip unzip tar pkg-config
+apt-get install -y autoconf-archive bison flex libfl-dev libc-ares-dev libicu-dev
+apt-get install -y libgoogle-glog-dev libbz2-dev libgflags-dev libgmock-dev libevent-dev
+apt-get install -y liblz4-dev libsodium-dev libelf-dev
+apt-get install -y autoconf automake g++ libnuma-dev libtool numactl unzip libdaxctl-dev
+apt-get install -y openjdk-11-jdk
+apt-get install -y maven cmake
+apt-get install -y chrpath patchelf
 
 # Install GCC 11.
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get install -y gcc-11 g++-11
-sudo rm -f /usr/bin/gcc /usr/bin/g++
-sudo ln -s /usr/bin/gcc-11 /usr/bin/gcc
-sudo ln -s /usr/bin/g++-11 /usr/bin/g++
+apt-get install -y software-properties-common
+add-apt-repository ppa:ubuntu-toolchain-r/test
+apt-get install -y gcc-11 g++-11
+rm -f /usr/bin/gcc /usr/bin/g++
+ln -s /usr/bin/gcc-11 /usr/bin/gcc
+ln -s /usr/bin/g++-11 /usr/bin/g++
 cc --version
 c++ --version

--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         runner: [
-          "ubuntu-24.04",
+          "ubuntu-latest",
           "ubuntu-24.04-arm"
         ]
         exclude:

--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -57,10 +57,11 @@ jobs:
             ut-java-ut-ubuntu24-${{runner.arch}}-ccache-
       - name: Run setup script / Build and run UTs
         run: |
-          docker run -v ${{ github.workspace }}:/work -w /velox4j ubuntu:24.04 bash -c "
+          docker run -v ${{ github.workspace }}:/velox4j -w / ubuntu:24.04 bash -c "
             export CCACHE_DIR=/velox4j/.ccache
             export CCACHE_MAXSIZE=3000M
-            bash /velox4j/.github/workflows/scripts/ut-java/setup-ubuntu24.sh
+            cd /velox4j
+            bash .github/workflows/scripts/ut-java/setup-ubuntu24.sh
             mvn clean test
           "
       - name: Save Ccache
@@ -84,10 +85,11 @@ jobs:
             ut-java-ut-centos7-ccache-
       - name: Run setup script / Build and run UTs
         run: |
-          docker run -v ${{ github.workspace }}:/work -w /velox4j centos:7 bash -c "
+          docker run -v ${{ github.workspace }}:/velox4j -w / centos:7 bash -c "
             export CCACHE_DIR=/velox4j/.ccache
             export CCACHE_MAXSIZE=3000M
-            bash /velox4j/.github/workflows/scripts/ut-java/setup-centos7.sh
+            cd /velox4j
+            bash .github/workflows/scripts/ut-java/setup-centos7.sh
             mvn clean test
           "
       - name: Save Ccache

--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -44,7 +44,7 @@ jobs:
           - runner: "ubuntu-24.04-arm"
     runs-on: ${{ matrix.runner }}
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      HOST_CCACHE_DIR: "${{ github.workspace }}/.ccache"
       CCACHE_MAXSIZE: 3000M
     steps:
       - uses: actions/checkout@v4
@@ -55,16 +55,18 @@ jobs:
           key: ut-java-ut-ubuntu24-${{runner.arch}}-ccache-${{github.sha}}
           restore-keys: |
             ut-java-ut-ubuntu24-${{runner.arch}}-ccache-
-      - name: Run setup script
+      - name: Run setup script / Build and run UTs
         run: |
-          bash .github/workflows/scripts/ut-java/setup-ubuntu24.sh
-      - name: Build and run UTs
-        run: |
-          mvn clean test
+          docker run -v ${{ github.workspace }}:/work -w /velox4j ubuntu:24.04 bash -c "
+            export HOST_CCACHE_DIR=/velox4j/.ccache
+            export CCACHE_MAXSIZE=3000M
+            bash /velox4j/.github/workflows/scripts/ut-java/setup-ubuntu24.sh
+            mvn clean test
+          "
       - name: Save Ccache
         uses: actions/cache/save@v4
         with:
-          path: '${{ env.CCACHE_DIR }}'
+          path: '${{ env.HOST_CCACHE_DIR }}'
           key: ut-java-ut-ubuntu24-${{runner.arch}}-ccache-${{github.sha}}
 
   ut-centos7:
@@ -82,10 +84,10 @@ jobs:
             ut-java-ut-centos7-ccache-
       - name: Run setup script / Build and run UTs
         run: |
-          docker run -v ${{ github.workspace }}:/work -w /work centos:7 bash -c "
-            export CCACHE_DIR=/work/.ccache
+          docker run -v ${{ github.workspace }}:/work -w /velox4j centos:7 bash -c "
+            export CCACHE_DIR=/velox4j/.ccache
             export CCACHE_MAXSIZE=3000M
-            bash .github/workflows/scripts/ut-java/setup-centos7.sh
+            bash /velox4j/.github/workflows/scripts/ut-java/setup-centos7.sh
             mvn clean test
           "
       - name: Save Ccache

--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -51,14 +51,14 @@ jobs:
       - name: Restore Ccache
         uses: actions/cache/restore@v4
         with:
-          path: '${{ env.CCACHE_DIR }}'
+          path: '${{ env.HOST_CCACHE_DIR }}'
           key: ut-java-ut-ubuntu24-${{runner.arch}}-ccache-${{github.sha}}
           restore-keys: |
             ut-java-ut-ubuntu24-${{runner.arch}}-ccache-
       - name: Run setup script / Build and run UTs
         run: |
           docker run -v ${{ github.workspace }}:/work -w /velox4j ubuntu:24.04 bash -c "
-            export HOST_CCACHE_DIR=/velox4j/.ccache
+            export CCACHE_DIR=/velox4j/.ccache
             export CCACHE_MAXSIZE=3000M
             bash /velox4j/.github/workflows/scripts/ut-java/setup-ubuntu24.sh
             mvn clean test


### PR DESCRIPTION
Run Ubuntu24 UTs in docker container to avoid instabilities introduced by GitHub hosted runner image updates.

Related to https://github.com/actions/runner-images/pull/11902
CI Failure https://github.com/velox4j/velox4j/actions/runs/14191138121/job/39781989955