### PR TITLE
UpIterators#asJavaIterator: Wait once blocked to avoid infinite loop

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
@@ -20,6 +20,7 @@ public final class UpIterators {
         final UpIterator.State state = upIterator.advance();
         switch (state) {
           case BLOCKED:
+            upIterator.waitFor();
             continue;
           case AVAILABLE:
             return true;


### PR DESCRIPTION
Otherwise there's a inf loop to cause CPU inefficiency or memory overuse.