### PR TITLE
ExternalStreamTableHandle support toString

### DIFF
--- a/src/main/cpp/main/velox4j/connector/ExternalStream.h
+++ b/src/main/cpp/main/velox4j/connector/ExternalStream.h
@@ -76,6 +76,10 @@ class ExternalStreamTableHandle
  public:
   explicit ExternalStreamTableHandle(const std::string& connectorId);
 
+  std::string toString() const override {
+    return "ExternalStreamTableHandle";
+  }
+
   folly::dynamic serialize() const override;
 
   static void registerSerDe();


### PR DESCRIPTION
Att, if else, when call plan.toString(), it will throw exception