### PR TITLE
Log the unclosed JNI objects on WARN level when session is exiting

### DIFF
--- a/src/main/cpp/main/velox4j/arrow/Arrow.h
+++ b/src/main/cpp/main/velox4j/arrow/Arrow.h
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <arrow/api.h>
 #include <arrow/c/abi.h>
 #include <velox/vector/ComplexVector.h>
-
-#pragma once
 
 namespace velox4j {
 void fromBaseVectorToArrow(

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -91,7 +91,7 @@ jlong queryExecutorExecute(
     jlong queryExecutorId) {
   JNI_METHOD_START
   auto exec = ObjectStore::retrieve<QueryExecutor>(queryExecutorId);
-  return sessionOf(env, javaThis)->objectStore()->save(exec->execute());
+  return sessionOf(env, javaThis)->objectStore()->save<UpIterator>(exec->execute());
   JNI_METHOD_END(-1L)
 }
 

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -56,7 +56,7 @@ jlong createMemoryManager(JNIEnv* env, jobject javaThis, jobject jListener) {
 jlong createSession(JNIEnv* env, jobject javaThis, long memoryManagerId) {
   JNI_METHOD_START
   auto mm = ObjectStore::retrieve<MemoryManager>(memoryManagerId);
-  return ObjectStore::global()->save(std::make_unique<Session>(mm.get()));
+  return ObjectStore::global()->save(std::make_shared<Session>(mm.get()));
   JNI_METHOD_END(-1L)
 }
 

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -33,9 +33,9 @@ ObjectStore::~ObjectStore() {
     ResourceHandle handle = (*itr).first;
     LOG(WARNING)
         << "Unclosed object ["
-        << " Store ID: " << storeId_ << ", Resource handle ID: " << handle
+        << "Store ID: " << storeId_ << ", Resource handle ID: " << handle
         << ", Description: " << description
-        << "]found when object store is closing. Velox4J will"
+        << "] is found when object store is closing. Velox4J will"
            " destroy it automatically but it's recommended to manually close"
            " the object through the Java API CppObject#close() after use,"
            " to minimize peak memory pressure of the application.";

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -32,12 +32,13 @@ ObjectStore::~ObjectStore() {
     const std::string_view description = (*itr).second;
     ResourceHandle handle = (*itr).first;
     LOG(WARNING)
-        << "Unclosed object found when object store is closing. Velox4J will"
+        << "Unclosed object ["
+        << " Store ID: " << storeId_ << ", Resource handle ID: " << handle
+        << ", Description: " << description
+        << "]found when object store is closing. Velox4J will"
            " destroy it automatically but it's recommended to manually close"
            " the object through the Java API CppObject#close() after use,"
-           " to minimize peak memory pressure of the application. Store ID: "
-        << storeId_ << ", Resource handle ID: " << handle
-        << ", Description: " << description;
+           " to minimize peak memory pressure of the application.";
     store_.erase(handle);
   }
   stores().erase(storeId_);

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-#include <glog/logging.h>
-#include <iostream>
 #include "ObjectStore.h"
+#include <glog/logging.h>
 
 namespace velox4j {
 // static
@@ -30,7 +29,11 @@ ObjectStore::~ObjectStore() {
   // destructing in reversed order (the last added object destructed first)
   const std::lock_guard<std::mutex> lock(mtx_);
   for (auto itr = aliveObjects_.rbegin(); itr != aliveObjects_.rend(); ++itr) {
-    ResourceHandle handle = *itr;
+    const std::string description = (*itr).second;
+    ResourceHandle handle = (*itr).first;
+    LOG(WARNING)
+        << "Unreleased object found when object store is closing. Store ID: "
+        << storeId_ << " Description: " << description;
     store_.erase(handle);
   }
   stores().erase(storeId_);

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -33,7 +33,8 @@ ObjectStore::~ObjectStore() {
     ResourceHandle handle = (*itr).first;
     LOG(WARNING)
         << "Unreleased object found when object store is closing. Store ID: "
-        << storeId_ << " Description: " << description;
+        << storeId_ << ", Resource handle ID: " << handle
+        << ", Description: " << description;
     store_.erase(handle);
   }
   stores().erase(storeId_);

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -29,7 +29,7 @@ ObjectStore::~ObjectStore() {
   // destructing in reversed order (the last added object destructed first)
   const std::lock_guard<std::mutex> lock(mtx_);
   for (auto itr = aliveObjects_.rbegin(); itr != aliveObjects_.rend(); ++itr) {
-    const std::string description = (*itr).second;
+    const std::string_view description = (*itr).second;
     ResourceHandle handle = (*itr).first;
     LOG(WARNING)
         << "Unreleased object found when object store is closing. Store ID: "

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -32,7 +32,10 @@ ObjectStore::~ObjectStore() {
     const std::string_view description = (*itr).second;
     ResourceHandle handle = (*itr).first;
     LOG(WARNING)
-        << "Unreleased object found when object store is closing. Store ID: "
+        << "Unclosed object found when object store is closing. Velox4J will"
+           " destroy it automatically but it's recommended to manually close"
+           " the object through the Java API CppObject#close() after use,"
+           " to minimize peak memory pressure of the application. Store ID: "
         << storeId_ << ", Resource handle ID: " << handle
         << ", Description: " << description;
     store_.erase(handle);

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -36,13 +36,6 @@ ObjectStore::~ObjectStore() {
   stores().erase(storeId_);
 }
 
-ObjectHandle ObjectStore::save(std::shared_ptr<void> obj) {
-  const std::lock_guard<std::mutex> lock(mtx_);
-  ResourceHandle handle = store_.insert(std::move(obj));
-  aliveObjects_.insert(handle);
-  return toObjHandle(handle);
-}
-
 void ObjectStore::releaseInternal(ResourceHandle handle) {
   const std::lock_guard<std::mutex> lock(mtx_);
   store_.erase(handle);

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <set>
+#include <map>
 #include "ResourceMap.h"
 
 namespace velox4j {
@@ -78,8 +78,9 @@ public:
 template <typename T>
 ObjectHandle save(std::shared_ptr<T> obj) {
    const std::lock_guard<std::mutex> lock(mtx_);
+   const std::string description = typeid(T).name();
    ResourceHandle handle = store_.insert(std::move(obj));
-   aliveObjects_.insert(handle);
+   aliveObjects_.emplace(handle, description);
    return toObjHandle(handle);
 } 
 
@@ -97,6 +98,7 @@ private:
    const std::lock_guard<std::mutex> lock(mtx_);
    std::shared_ptr<void> object = store_.lookup(handle);
    // Programming carefully. This will lead to ub if wrong typename T was passed in.
+   VELOX_DCHECK_EQ(aliveObjects_.find(handle)->second, typeid(T).name());
    auto casted = std::static_pointer_cast<T>(object);
    return casted;
  }
@@ -106,7 +108,8 @@ private:
  explicit ObjectStore(StoreHandle storeId) : storeId_(storeId){};
  StoreHandle storeId_;
  ResourceMap<std::shared_ptr<void>> store_;
- std::set<ResourceHandle> aliveObjects_{};
+ // Preserves handles of objects in the store in order, with the text descriptions associated with them.
+ std::map<ResourceHandle, std::string> aliveObjects_{};
  std::mutex mtx_;
 };
 } // namespace gluten

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
@@ -78,7 +78,7 @@ public:
 template <typename T>
 ObjectHandle save(std::shared_ptr<T> obj) {
    const std::lock_guard<std::mutex> lock(mtx_);
-   const std::string description = typeid(T).name();
+   const std::string_view description = typeid(T).name();
    ResourceHandle handle = store_.insert(std::move(obj));
    aliveObjects_.emplace(handle, description);
    return toObjHandle(handle);
@@ -109,7 +109,7 @@ private:
  StoreHandle storeId_;
  ResourceMap<std::shared_ptr<void>> store_;
  // Preserves handles of objects in the store in order, with the text descriptions associated with them.
- std::map<ResourceHandle, std::string> aliveObjects_{};
+ std::map<ResourceHandle, std::string_view> aliveObjects_{};
  std::mutex mtx_;
 };
 } // namespace gluten

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
@@ -75,7 +75,13 @@ public:
    return storeId_;
  }
 
- ObjectHandle save(std::shared_ptr<void> obj);
+template <typename T>
+ObjectHandle save(std::shared_ptr<T> obj) {
+   const std::lock_guard<std::mutex> lock(mtx_);
+   ResourceHandle handle = store_.insert(std::move(obj));
+   aliveObjects_.insert(handle);
+   return toObjHandle(handle);
+} 
 
 private:
  static ResourceMap<ObjectStore*>& stores();

--- a/src/main/cpp/test/velox4j/test/Init.h
+++ b/src/main/cpp/test/velox4j/test/Init.h
@@ -14,14 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include "velox4j/init/Config.h"
 #include "velox4j/init/Init.h"
 
-#pragma once
-
 namespace velox4j {
-void testingEnsureInitializedForSpark() {
+inline void testingEnsureInitializedForSpark() {
   static std::once_flag flag;
   auto conf = std::make_shared<ConfigArray>(
       std::vector<std::pair<std::string, std::string>>{


### PR DESCRIPTION
From the current design of Velox4J, all Java objects implementing the interface `CppObject` are expected to be closed after use. While not closed, when the associated session is existing (via `Session#close()`), these unclosed objects will be automatically destroyed.

However if user all rely on this auto-close mechanism, peak memory usage of the application will be higher than expected because objects that should be released early survive longer than wanted. Hence, in the patch, we print a log for these unclosed objects to remind user manually close them in code. The log will look like:

```
W20250417 17:56:06.143730 302336 ObjectStore.cc:34] Unclosed object [Store ID: 13, Resource handle ID: 7, Description: N8facebook5velox10BaseVectorE] is found when object store is closing. Velox4J will destroy it automatically but it's recommended to manually close the object through the Java API CppObject#close() after use, to minimize peak memory pressure of the application.
W20250417 17:56:06.143747 302336 ObjectStore.cc:34] Unclosed object [Store ID: 13, Resource handle ID: 6, Description: N7velox4j9EvaluatorE] is found when object store is closing. Velox4J will destroy it automatically but it's recommended to manually close the object through the Java API CppObject#close() after use, to minimize peak memory pressure of the application.
W20250417 17:56:06.143762 302336 ObjectStore.cc:34] Unclosed object [Store ID: 13, Resource handle ID: 5, Description: N8facebook5velox17SelectivityVectorE] is found when object store is closing. Velox4J will destroy it automatically but it's recommended to manually close the object through the Java API CppObject#close() after use, to minimize peak memory pressure of the application.
W20250417 17:56:06.143767 302336 ObjectStore.cc:34] Unclosed object [Store ID: 13, Resource handle ID: 4, Description: N8facebook5velox10BaseVectorE] is found when object store is closing. Velox4J will destroy it automatically but it's recommended to manually close the object through the Java API CppObject#close() after use, to minimize peak memory pressure of the application.
```

The effort can also be ported to Apache Gluten.