### PR TITLE
New API to collect operator statistics from Velox

### DIFF
--- a/src/main/cpp/main/velox4j/iterator/UpIterator.h
+++ b/src/main/cpp/main/velox4j/iterator/UpIterator.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "velox4j/query/Query.h"
 #include <velox/vector/ComplexVector.h>
 
 namespace velox4j {
@@ -37,8 +38,12 @@ class UpIterator {
   // DTOR.
   virtual ~UpIterator() = default;
 
+  // Iteration control.
   virtual State advance() = 0;
   virtual void wait() = 0;
   virtual facebook::velox::RowVectorPtr get() = 0;
+
+  // Metrics.
+  virtual std::unique_ptr<QueryStats> collectStats() = 0;
 };
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -285,6 +285,10 @@ class ExternalStreamAsUpIterator : public UpIterator {
     return out;
   };
 
+  std::unique_ptr<QueryStats> collectStats() override {
+    return std::make_unique<QueryStats>(exec::TaskStats{});
+  }
+
  private:
   const std::shared_ptr<ExternalStream> es_;
   RowVectorPtr pending_{nullptr};

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -80,6 +80,16 @@ void upIteratorWait(JNIEnv* env, jobject javaThis, jlong itrId) {
   JNI_METHOD_END()
 }
 
+jstring upIteratorCollectStats(JNIEnv* env, jobject javaThis, jlong itrId) {
+  JNI_METHOD_START
+  auto itr = ObjectStore::retrieve<UpIterator>(itrId);
+  const auto queryStats = itr->collectStats();
+  const auto statsDynamic = queryStats->toJson();
+  const auto statsJson = folly::toPrettyJson(statsDynamic);
+  return env->NewStringUTF(statsJson.data());
+  JNI_METHOD_END(nullptr)
+}
+
 jstring variantInferType(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_START
   spotify::jni::JavaString jJson{env, json};
@@ -239,7 +249,9 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       nullptr);
   addNativeMethod(
-    "upIteratorWait", (void*)upIteratorWait, kTypeVoid, kTypeLong, nullptr);
+      "upIteratorWait", (void*)upIteratorWait, kTypeVoid, kTypeLong, nullptr);
+  addNativeMethod(
+      "upIteratorCollectStats", (void*)upIteratorCollectStats, kTypeString, kTypeLong, nullptr);
   addNativeMethod(
       "variantInferType",
       (void*)variantInferType,

--- a/src/main/cpp/main/velox4j/query/Query.cc
+++ b/src/main/cpp/main/velox4j/query/Query.cc
@@ -17,6 +17,8 @@
 
 #include "Query.h"
 
+#include <velox/exec/PlanNodeStats.h>
+
 namespace velox4j {
 using namespace facebook::velox;
 
@@ -107,5 +109,14 @@ std::shared_ptr<Query> Query::create(const folly::dynamic& obj, void* context) {
 void Query::registerSerDe() {
   auto& registry = DeserializationWithContextRegistryForSharedPtr();
   registry.Register("velox4j.Query", create);
+}
+
+QueryStats::QueryStats(const facebook::velox::exec::TaskStats& taskStats)
+    : taskStats_(taskStats) {}
+
+folly::dynamic QueryStats::toJson() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["planStats"] = exec::toPlanStatsJson(taskStats_);
+  return obj;
 }
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/query/Query.h
+++ b/src/main/cpp/main/velox4j/query/Query.h
@@ -18,9 +18,11 @@
 #pragma once
 
 #include <velox/core/PlanNode.h>
-#include <utility>
 #include "BoundSplit.h"
 #include "velox4j/config/Config.h"
+
+#include <velox/exec/Operator.h>
+#include <velox/exec/TaskStats.h>
 
 namespace velox4j {
 class Query : public facebook::velox::ISerializable {
@@ -51,5 +53,15 @@ class Query : public facebook::velox::ISerializable {
   const std::vector<std::shared_ptr<BoundSplit>> boundSplits_;
   const std::shared_ptr<const ConfigArray> queryConfig_;
   const std::shared_ptr<const ConnectorConfigArray> connectorConfig_;
+};
+
+class QueryStats {
+public:
+  QueryStats(const facebook::velox::exec::TaskStats& taskStats);
+
+  folly::dynamic toJson() const;
+
+private:
+  facebook::velox::exec::TaskStats taskStats_;
 };
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -109,6 +109,11 @@ class Out : public UpIterator {
     return out;
   }
 
+  std::unique_ptr<QueryStats> collectStats() override {
+    const auto stats = task_->taskStats();
+    return std::make_unique<QueryStats>(stats);
+  }
+
  private:
   State advance0(bool wait) {
     while (true) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
@@ -5,6 +5,7 @@ import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.jni.CppObject;
 import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
+import io.github.zhztheplayer.velox4j.query.QueryStats;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +54,10 @@ public class UpIterator implements CppObject {
 
   public RowVector get() {
     return jniApi.upIteratorGet(this);
+  }
+
+  public QueryStats collectStats() {
+    return StaticJniApi.get().upIteratorCollectStats(this);
   }
 
   @Override

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class UpIterator implements CppObject {
-  private static final Map<Integer, State> ID_LOOKUP = new HashMap<>();
+  private static final Map<Integer, State> STATE_ID_LOOKUP = new HashMap<>();
 
   public enum State {
     AVAILABLE(0),
@@ -18,16 +18,16 @@ public class UpIterator implements CppObject {
     FINISHED(2);
 
     public static State get(int id) {
-      Preconditions.checkArgument(ID_LOOKUP.containsKey(id), "ID not found: %d", id);
-      return ID_LOOKUP.get(id);
+      Preconditions.checkArgument(STATE_ID_LOOKUP.containsKey(id), "ID not found: %d", id);
+      return STATE_ID_LOOKUP.get(id);
     }
 
     private final int id;
 
     State(int id) {
       this.id = id;
-      Preconditions.checkArgument(!ID_LOOKUP.containsKey(id));
-      ID_LOOKUP.put(id, this);
+      Preconditions.checkArgument(!STATE_ID_LOOKUP.containsKey(id));
+      STATE_ID_LOOKUP.put(id, this);
     }
 
     public int getId() {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -9,6 +9,7 @@ import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
+import io.github.zhztheplayer.velox4j.query.QueryStats;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 import io.github.zhztheplayer.velox4j.serializable.ISerializableCo;
@@ -55,6 +56,11 @@ public class StaticJniApi {
 
   public void upIteratorWait(UpIterator itr) {
     jni.upIteratorWait(itr.id());
+  }
+
+  public QueryStats upIteratorCollectStats(UpIterator itr) {
+    final String statsJson = jni.upIteratorCollectStats(itr.id());
+    return QueryStats.fromJson(statsJson);
   }
 
   public Type variantInferType(Variant variant) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -25,6 +25,7 @@ public class StaticJniWrapper {
   // For UpIterator.
   native int upIteratorAdvance(long id);
   native void upIteratorWait(long id);
+  native String upIteratorCollectStats(long id);
 
   // For Variant.
   native String variantInferType(String json);

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/QueryStats.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/QueryStats.java
@@ -1,0 +1,43 @@
+package io.github.zhztheplayer.velox4j.query;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
+import io.github.zhztheplayer.velox4j.exception.VeloxException;
+import io.github.zhztheplayer.velox4j.serde.Serde;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class QueryStats {
+  private final ArrayNode planStatsDynamic;
+
+  private QueryStats(JsonNode planStatsDynamic) {
+    this.planStatsDynamic = (ArrayNode) planStatsDynamic;
+  }
+
+  public static QueryStats fromJson(String statsJson) {
+    final JsonNode dynamic = Serde.parseTree(statsJson);
+    final JsonNode planStatsDynamic = Preconditions.checkNotNull(dynamic.get("planStats"),
+        "Plan statistics not found in query statistics");
+    return new QueryStats(planStatsDynamic);
+  }
+
+  public ObjectNode planStats(String planNodeId) {
+    final List<ObjectNode> out = new ArrayList<>();
+    for (JsonNode each : planStatsDynamic) {
+      if (Objects.equals(each.get("planNodeId").asText(), planNodeId)) {
+        out.add((ObjectNode) each);
+      }
+    }
+    if (out.isEmpty()) {
+      throw new VeloxException(String.format("Query plan statistics for plan node not found, node ID: %s", planNodeId));
+    }
+    if (out.size() != 1) {
+      throw new VeloxException(String.format("More than one nodes (%d total) with the same node ID found in query plan statistics, node ID: %s", out.size(), planNodeId));
+    }
+    return out.get(0);
+  }
+}

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -209,11 +209,6 @@ public class QueryTest {
     final AggregationNode aggregationNode = newSampleAggregationNodeSumNationKeyByRegionKey("id-2", scanNode);
     final Query query = new Query(aggregationNode, splits, Config.empty(), ConnectorConfig.empty());
     final UpIterator itr = session.queryOps().execute(query);
-    UpIteratorTests.assertIterator(itr)
-        .assertNumRowVectors(1)
-        .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-aggregate-1.tsv"))
-        .run();
-
     final QueryStats queryStats = itr.collectStats();
 
     final JsonNode scanStats = queryStats.planStats("id-1");

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -1,5 +1,6 @@
 package io.github.zhztheplayer.velox4j.query;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.aggregate.Aggregate;
 import io.github.zhztheplayer.velox4j.aggregate.AggregateStep;
@@ -188,31 +189,43 @@ public class QueryTest {
     final List<BoundSplit> splits = List.of(
         newSampleSplit(scanNode, file)
     );
-    final AggregationNode aggregationNode = new AggregationNode("id-2", AggregateStep.SINGLE,
-        List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
-        List.of(),
-        List.of("cnt"),
-        List.of(new Aggregate(
-            new CallTypedExpr(new BigIntType(), List.of(
-                FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
-                "sum"),
-            List.of(new BigIntType()),
-            null,
-            List.of(),
-            List.of(),
-            false
-        )),
-        false,
-        List.of(scanNode),
-        null,
-        List.of()
-    );
+    final AggregationNode aggregationNode = newSampleAggregationNodeSumNationKeyByRegionKey("id-2", scanNode);
     final Query query = new Query(aggregationNode, splits, Config.empty(), ConnectorConfig.empty());
     final UpIterator itr = session.queryOps().execute(query);
     UpIteratorTests.assertIterator(itr)
         .assertNumRowVectors(1)
         .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-aggregate-1.tsv"))
         .run();
+  }
+
+  @Test
+  public void testAggregateStats() {
+    final File file = TpchTests.Table.NATION.file();
+    final RowType outputType = TpchTests.Table.NATION.schema();
+    final TableScanNode scanNode = newSampleTableScanNode("id-1", outputType);
+    final List<BoundSplit> splits = List.of(
+        newSampleSplit(scanNode, file)
+    );
+    final AggregationNode aggregationNode = newSampleAggregationNodeSumNationKeyByRegionKey("id-2", scanNode);
+    final Query query = new Query(aggregationNode, splits, Config.empty(), ConnectorConfig.empty());
+    final UpIterator itr = session.queryOps().execute(query);
+    UpIteratorTests.assertIterator(itr)
+        .assertNumRowVectors(1)
+        .assertRowVectorToString(0, ResourceTests.readResourceAsString("query-output/tpch-aggregate-1.tsv"))
+        .run();
+
+    final QueryStats queryStats = itr.collectStats();
+
+    final JsonNode scanStats = queryStats.planStats("id-1");
+    Assert.assertEquals("TableScan", scanStats.get("operatorType").asText());
+    Assert.assertEquals(1, scanStats.get("numDrivers").asInt());
+    Assert.assertEquals(1, scanStats.get("numSplits").asInt());
+    Assert.assertEquals(25, scanStats.get("inputRows").asInt());
+
+    final JsonNode aggStats = queryStats.planStats("id-2");
+    Assert.assertEquals("Aggregation", aggStats.get("operatorType").asText());
+    Assert.assertEquals(25, aggStats.get("inputRows").asInt());
+    Assert.assertEquals(5, aggStats.get("outputRows").asInt());
   }
 
   @Test
@@ -715,5 +728,28 @@ public class QueryTest {
         toAssignments(outputType)
     );
     return scanNode;
+  }
+
+  private static AggregationNode newSampleAggregationNodeSumNationKeyByRegionKey(String planNodeId, PlanNode source) {
+    final AggregationNode aggregationNode = new AggregationNode(planNodeId, AggregateStep.SINGLE,
+        List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
+        List.of(),
+        List.of("cnt"),
+        List.of(new Aggregate(
+            new CallTypedExpr(new BigIntType(), List.of(
+                FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
+                "sum"),
+            List.of(new BigIntType()),
+            null,
+            List.of(),
+            List.of(),
+            false
+        )),
+        false,
+        List.of(source),
+        null,
+        List.of()
+    );
+    return aggregationNode;
   }
 }


### PR DESCRIPTION
Add a new API `UpIterator#collectStats` for collecting Velox operator statistics to Java.

Code example:

```java
final UpIterator itr = session.queryOps().execute(query);
final QueryStats queryStats = itr.collectStats();

final JsonNode scanStats = queryStats.planStats("id-1");
Assert.assertEquals("TableScan", scanStats.get("operatorType").asText());
Assert.assertEquals(1, scanStats.get("numDrivers").asInt());
Assert.assertEquals(1, scanStats.get("numSplits").asInt());
Assert.assertEquals(25, scanStats.get("inputRows").asInt());

final JsonNode aggStats = queryStats.planStats("id-2");
Assert.assertEquals("Aggregation", aggStats.get("operatorType").asText());
Assert.assertEquals(25, aggStats.get("inputRows").asInt());
Assert.assertEquals(5, aggStats.get("outputRows").asInt());
```