### PR TITLE
Make UpIterator abstract

### DIFF
--- a/src/main/cpp/main/velox4j/iterator/UpIterator.h
+++ b/src/main/cpp/main/velox4j/iterator/UpIterator.h
@@ -42,8 +42,5 @@ class UpIterator {
   virtual State advance() = 0;
   virtual void wait() = 0;
   virtual facebook::velox::RowVectorPtr get() = 0;
-
-  // Metrics.
-  virtual std::unique_ptr<QueryStats> collectStats() = 0;
 };
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -91,7 +91,7 @@ jlong queryExecutorExecute(
     jlong queryExecutorId) {
   JNI_METHOD_START
   auto exec = ObjectStore::retrieve<QueryExecutor>(queryExecutorId);
-  return sessionOf(env, javaThis)->objectStore()->save<UpIterator>(exec->execute());
+  return sessionOf(env, javaThis)->objectStore()->save<SerialTask>(exec->execute());
   JNI_METHOD_END(-1L)
 }
 
@@ -283,10 +283,6 @@ class ExternalStreamAsUpIterator : public UpIterator {
     auto out = pending_;
     pending_ = nullptr;
     return out;
-  };
-
-  std::unique_ptr<QueryStats> collectStats() override {
-    return std::make_unique<QueryStats>(exec::TaskStats{});
   }
 
  private:

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -20,6 +20,8 @@
 #include <velox/common/encode/Base64.h>
 #include <velox/exec/TableWriter.h>
 #include <velox/vector/VectorSaver.h>
+#include <velox4j/query/QueryExecutor.h>
+
 #include "JniCommon.h"
 #include "JniError.h"
 #include "velox4j/arrow/Arrow.h"
@@ -80,10 +82,10 @@ void upIteratorWait(JNIEnv* env, jobject javaThis, jlong itrId) {
   JNI_METHOD_END()
 }
 
-jstring upIteratorCollectStats(JNIEnv* env, jobject javaThis, jlong itrId) {
+jstring serialTaskCollectStats(JNIEnv* env, jobject javaThis, jlong stId) {
   JNI_METHOD_START
-  auto itr = ObjectStore::retrieve<UpIterator>(itrId);
-  const auto queryStats = itr->collectStats();
+  auto serialTask = ObjectStore::retrieve<SerialTask>(stId);
+  const auto queryStats = serialTask->collectStats();
   const auto statsDynamic = queryStats->toJson();
   const auto statsJson = folly::toPrettyJson(statsDynamic);
   return env->NewStringUTF(statsJson.data());
@@ -251,7 +253,7 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
   addNativeMethod(
       "upIteratorWait", (void*)upIteratorWait, kTypeVoid, kTypeLong, nullptr);
   addNativeMethod(
-      "upIteratorCollectStats", (void*)upIteratorCollectStats, kTypeString, kTypeLong, nullptr);
+      "serialTaskCollectStats", (void*)serialTaskCollectStats, kTypeString, kTypeLong, nullptr);
   addNativeMethod(
       "variantInferType",
       (void*)variantInferType,

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/GenericUpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/GenericUpIterator.java
@@ -1,0 +1,35 @@
+package io.github.zhztheplayer.velox4j.iterator;
+
+import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.jni.JniApi;
+import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
+
+public class GenericUpIterator implements UpIterator {
+  private final JniApi jniApi;
+  private final long id;
+
+  public GenericUpIterator(JniApi jniApi, long id) {
+    this.jniApi = jniApi;
+    this.id = id;
+  }
+
+  @Override
+  public State advance() {
+    return StaticJniApi.get().upIteratorAdvance(this);
+  }
+
+  @Override
+  public void waitFor() {
+    StaticJniApi.get().upIteratorWait(this);
+  }
+
+  @Override
+  public RowVector get() {
+    return jniApi.upIteratorGet(this);
+  }
+
+  @Override
+  public long id() {
+    return id;
+  }
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
@@ -10,13 +10,19 @@ import io.github.zhztheplayer.velox4j.query.QueryStats;
 import java.util.HashMap;
 import java.util.Map;
 
-public class UpIterator implements CppObject {
-  private static final Map<Integer, State> STATE_ID_LOOKUP = new HashMap<>();
-
-  public enum State {
+public interface UpIterator extends CppObject {
+  enum State {
     AVAILABLE(0),
     BLOCKED(1),
     FINISHED(2);
+
+    private static Map<Integer, State> STATE_ID_LOOKUP = new HashMap<>();
+
+    static {
+      for (State state : State.values()) {
+        STATE_ID_LOOKUP.put(state.id, state);
+      }
+    }
 
     public static State get(int id) {
       Preconditions.checkArgument(STATE_ID_LOOKUP.containsKey(id), "ID not found: %d", id);
@@ -27,8 +33,6 @@ public class UpIterator implements CppObject {
 
     State(int id) {
       this.id = id;
-      Preconditions.checkArgument(!STATE_ID_LOOKUP.containsKey(id));
-      STATE_ID_LOOKUP.put(id, this);
     }
 
     public int getId() {
@@ -36,32 +40,9 @@ public class UpIterator implements CppObject {
     }
   }
 
-  private final JniApi jniApi;
-  private final long id;
+  State advance();
 
-  public UpIterator(JniApi jniApi, long id) {
-    this.jniApi = jniApi;
-    this.id = id;
-  }
+  void waitFor();
 
-  public State advance() {
-    return StaticJniApi.get().upIteratorAdvance(this);
-  }
-
-  public void waitFor() {
-    StaticJniApi.get().upIteratorWait(this);
-  }
-
-  public RowVector get() {
-    return jniApi.upIteratorGet(this);
-  }
-
-  public QueryStats collectStats() {
-    return StaticJniApi.get().upIteratorCollectStats(this);
-  }
-
-  @Override
-  public long id() {
-    return id;
-  }
+  RowVector get();
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -9,10 +9,12 @@ import io.github.zhztheplayer.velox4j.data.VectorEncoding;
 import io.github.zhztheplayer.velox4j.eval.Evaluation;
 import io.github.zhztheplayer.velox4j.eval.Evaluator;
 import io.github.zhztheplayer.velox4j.iterator.DownIterator;
+import io.github.zhztheplayer.velox4j.iterator.GenericUpIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.query.Query;
 import io.github.zhztheplayer.velox4j.query.QueryExecutor;
+import io.github.zhztheplayer.velox4j.query.SerialTask;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 import io.github.zhztheplayer.velox4j.serializable.ISerializableCo;
@@ -58,8 +60,8 @@ public final class JniApi {
     return new QueryExecutor(this, jni.createQueryExecutor(queryJson));
   }
 
-  public UpIterator queryExecutorExecute(QueryExecutor executor) {
-    return new UpIterator(this, jni.queryExecutorExecute(executor.id()));
+  public SerialTask queryExecutorExecute(QueryExecutor executor) {
+    return new SerialTask(this, jni.queryExecutorExecute(executor.id()));
   }
 
   public RowVector upIteratorGet(UpIterator itr) {
@@ -120,7 +122,7 @@ public final class JniApi {
 
   @VisibleForTesting
   public UpIterator createUpIteratorWithExternalStream(ExternalStream es) {
-    return new UpIterator(this, jni.createUpIteratorWithExternalStream(es.id()));
+    return new GenericUpIterator(this, jni.createUpIteratorWithExternalStream(es.id()));
   }
 
   private BaseVector baseVectorWrap(long id) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -10,6 +10,7 @@ import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.query.QueryStats;
+import io.github.zhztheplayer.velox4j.query.SerialTask;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 import io.github.zhztheplayer.velox4j.serializable.ISerializableCo;
@@ -58,8 +59,8 @@ public class StaticJniApi {
     jni.upIteratorWait(itr.id());
   }
 
-  public QueryStats upIteratorCollectStats(UpIterator itr) {
-    final String statsJson = jni.upIteratorCollectStats(itr.id());
+  public QueryStats serialTaskCollectStats(SerialTask serialTask) {
+    final String statsJson = jni.serialTaskCollectStats(serialTask.id());
     return QueryStats.fromJson(statsJson);
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -25,7 +25,9 @@ public class StaticJniWrapper {
   // For UpIterator.
   native int upIteratorAdvance(long id);
   native void upIteratorWait(long id);
-  native String upIteratorCollectStats(long id);
+
+  // For SerialTask.
+  native String serialTaskCollectStats(long id);
 
   // For Variant.
   native String variantInferType(String json);

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/Queries.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/Queries.java
@@ -10,7 +10,7 @@ public class Queries {
     this.jniApi = jniApi;
   }
 
-  public UpIterator execute(Query query) {
+  public SerialTask execute(Query query) {
     try (final QueryExecutor exec = jniApi.createQueryExecutor(query)) {
       return exec.execute();
     }

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/QueryExecutor.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/QueryExecutor.java
@@ -18,7 +18,7 @@ public class QueryExecutor implements CppObject {
     return id;
   }
 
-  public UpIterator execute() {
+  public SerialTask execute() {
     return jniApi.queryExecutorExecute(this);
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/query/SerialTask.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/query/SerialTask.java
@@ -1,0 +1,40 @@
+package io.github.zhztheplayer.velox4j.query;
+
+import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.iterator.UpIterator;
+import io.github.zhztheplayer.velox4j.jni.JniApi;
+import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
+
+public class SerialTask implements UpIterator {
+  private final JniApi jniApi;
+  private final long id;
+
+  public SerialTask(JniApi jniApi, long id) {
+    this.jniApi = jniApi;
+    this.id = id;
+  }
+
+  @Override
+  public State advance() {
+    return StaticJniApi.get().upIteratorAdvance(this);
+  }
+
+  @Override
+  public void waitFor() {
+    StaticJniApi.get().upIteratorWait(this);
+  }
+
+  @Override
+  public RowVector get() {
+    return jniApi.upIteratorGet(this);
+  }
+
+  @Override
+  public long id() {
+    return id;
+  }
+
+  public QueryStats collectStats() {
+    return StaticJniApi.get().serialTaskCollectStats(this);
+  }
+}

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -208,9 +208,9 @@ public class QueryTest {
     );
     final AggregationNode aggregationNode = newSampleAggregationNodeSumNationKeyByRegionKey("id-2", scanNode);
     final Query query = new Query(aggregationNode, splits, Config.empty(), ConnectorConfig.empty());
-    final UpIterator itr = session.queryOps().execute(query);
-    UpIteratorTests.collect(itr);
-    final QueryStats queryStats = itr.collectStats();
+    final SerialTask serialTask = session.queryOps().execute(query);
+    UpIteratorTests.collect(serialTask);
+    final QueryStats queryStats = serialTask.collectStats();
 
     final JsonNode scanStats = queryStats.planStats("id-1");
     Assert.assertEquals("TableScan", scanStats.get("operatorType").asText());


### PR DESCRIPTION
Make `UpIterator` an Java `Interface`, mapping to C++ side `UpIterator` virtual class. By doing this we can move APIs that are specific to certain `UpIterator` variations down to their own class definitions.