### PR TITLE
`UpIterator` supports non-blocking `hasNext`

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/CloseableIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/CloseableIterator.java
@@ -3,4 +3,12 @@ package io.github.zhztheplayer.velox4j.iterator;
 import java.util.Iterator;
 
 public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
+    /*
+     * Prepares the next element in the iterator.
+     *
+     * @param blocking If true, the method will block until the next element is available.
+     *                 If false, the method will return immediately if no element is available.
+     * @return true if the next element is prepared successfully, false otherwise.
+     */
+    boolean hasNext(boolean blocking);
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterator.java
@@ -30,5 +30,8 @@ public interface DownIterator {
   @CalledFromNative
   void close();
 
+  void finish();
+
   State advance0();
+
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterators.java
@@ -2,6 +2,7 @@ package io.github.zhztheplayer.velox4j.iterator;
 
 import com.google.common.base.Preconditions;
 import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.exception.VeloxException;
 
 import java.util.Iterator;
 import java.util.Queue;
@@ -47,12 +48,19 @@ public final class DownIterators {
     public void close() {
 
     }
+
+    @Override
+    public void finish() {
+      throw new VeloxException("#finish is not implemented");
+    }
   }
 
   private static class FromBlockingQueue implements DownIterator {
     private final BlockingQueue<RowVector> queue;
     private RowVector pending = null;
+    private RowVector prevRowVector = null;
     private AtomicBoolean closed = new AtomicBoolean(false);
+    private AtomicBoolean finished = new AtomicBoolean(false);
 
     public FromBlockingQueue(BlockingQueue<RowVector> queue) {
       this.queue = queue;
@@ -60,8 +68,19 @@ public final class DownIterators {
 
     @Override
     public State advance0() {
+      /*
+       * DownIterator owns the RowVector and is responsible for releasing its resources.
+       * It's safe to release previous RowVector here.
+       */
+      if (prevRowVector != null) {
+        prevRowVector.close();
+        prevRowVector = null;
+      }
       if (pending != null) {
         return State.AVAILABLE;
+      }
+      if (finished.get() && queue.isEmpty()) {
+        return State.FINISHED;
       }
       if (queue.isEmpty()) {
         return State.BLOCKED;
@@ -80,6 +99,11 @@ public final class DownIterators {
           throw new InterruptedException();
         }
         pending = queue.poll(100L, TimeUnit.MILLISECONDS);
+        if (pending == null && finished.get()) {
+          // If the queue is empty and finished, we should return
+          // to avoid blocking forever.
+          return;
+        }
       }
     }
 
@@ -87,15 +111,23 @@ public final class DownIterators {
     public long get() {
       if (pending != null) {
         final RowVector out = pending;
+        prevRowVector = pending;
         pending = null;
         return out.id();
       }
-      return queue.remove().id();
+      prevRowVector = queue.remove();
+      return prevRowVector.id();
+      // return queue.remove().id();
     }
 
     @Override
     public void close() {
       closed.compareAndSet(false, true);
+    }
+
+    @Override
+    public void finish() {
+      finished.compareAndSet(false, true);
     }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
@@ -14,6 +14,29 @@ public final class UpIterators {
       this.upIterator = upIterator;
     }
 
+    private boolean couldAdvance() {
+      final UpIterator.State state = upIterator.advance();
+      switch (state) {
+        case BLOCKED:
+          return false;
+        case AVAILABLE:
+          return true;
+        case FINISHED:
+          return false;
+        default:
+          throw new IllegalStateException("Unknown state: " + state);
+      }
+    }
+
+    @Override
+    public boolean hasNext(boolean blocking) {
+      if (blocking) {
+        return hasNext();
+      } else {
+        return couldAdvance();
+      }
+    }
+
     @Override
     public boolean hasNext() {
       while (true) {


### PR DESCRIPTION

Add a new non-blocking `hasNext` for `UpIterator`, fix  https://github.com/bigo-sg/gluten/issues/18.

The  PR for `gluten` is at https://github.com/bigo-sg/gluten/pull/20

