### PR TITLE
Add API UpIterators#asInfiniteIterator for user-friendly non-blocking execution

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/InfiniteIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/InfiniteIterator.java
@@ -1,0 +1,9 @@
+package io.github.zhztheplayer.velox4j.iterator;
+
+public interface InfiniteIterator<T> extends AutoCloseable {
+  boolean available();
+
+  void waitFor();
+
+  T get();
+}

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
@@ -67,7 +67,7 @@ public final class UpIterators {
           isAvailable = true;
           return true;
         case FINISHED:
-          throw new VeloxException("InfiniteIterator was closed by user");
+          throw new VeloxException("InfiniteIterator reaches FINISHED state, which is not supposed to happen");
         default:
           throw new IllegalStateException("Unknown state: " + state);
       }
@@ -87,7 +87,7 @@ public final class UpIterators {
           isAvailable = true;
           return;
         case FINISHED:
-          throw new VeloxException("InfiniteIterator was closed by user");
+          throw new VeloxException("InfiniteIterator reaches FINISHED state, which is not supposed to happen");
         default:
           throw new IllegalStateException("Unknown state: " + state);
       }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterators.java
@@ -1,10 +1,15 @@
 package io.github.zhztheplayer.velox4j.iterator;
 
 import io.github.zhztheplayer.velox4j.data.RowVector;
+import io.github.zhztheplayer.velox4j.exception.VeloxException;
 
 public final class UpIterators {
   public static CloseableIterator<RowVector> asJavaIterator(UpIterator upIterator) {
     return new AsJavaIterator(upIterator);
+  }
+
+  public static InfiniteIterator<RowVector> asInfiniteIterator(UpIterator upIterator) {
+    return new AsInfiniteIterator(upIterator);
   }
 
   private static class AsJavaIterator implements CloseableIterator<RowVector> {
@@ -12,28 +17,6 @@ public final class UpIterators {
 
     private AsJavaIterator(UpIterator upIterator) {
       this.upIterator = upIterator;
-    }
-
-    private boolean couldAdvance() {
-      final UpIterator.State state = upIterator.advance();
-      switch (state) {
-        case BLOCKED:
-          return false;
-        case AVAILABLE:
-          return true;
-        case FINISHED:
-          return false;
-        default:
-          throw new IllegalStateException("Unknown state: " + state);
-      }
-    }
-
-    public boolean hasNext(boolean blocking) {
-      if (blocking) {
-        return hasNext();
-      } else {
-        return couldAdvance();
-      }
     }
 
     @Override
@@ -55,6 +38,69 @@ public final class UpIterators {
     @Override
     public RowVector next() {
       return upIterator.get();
+    }
+
+    @Override
+    public void close() throws Exception {
+      upIterator.close();
+    }
+  }
+
+  private static class AsInfiniteIterator implements InfiniteIterator<RowVector> {
+    private final UpIterator upIterator;
+    private boolean isAvailable = false;
+
+    private AsInfiniteIterator(UpIterator upIterator) {
+      this.upIterator = upIterator;
+    }
+
+    @Override
+    public boolean available() {
+      if (isAvailable) {
+        return true;
+      }
+      final UpIterator.State state = upIterator.advance();
+      switch (state) {
+        case BLOCKED:
+          return false;
+        case AVAILABLE:
+          isAvailable = true;
+          return true;
+        case FINISHED:
+          throw new VeloxException("InfiniteIterator was closed by user");
+        default:
+          throw new IllegalStateException("Unknown state: " + state);
+      }
+    }
+
+    @Override
+    public void waitFor() {
+      if (isAvailable) {
+        return;
+      }
+      final UpIterator.State state = upIterator.advance();
+      switch (state) {
+        case BLOCKED:
+          upIterator.waitFor();
+          return;
+        case AVAILABLE:
+          isAvailable = true;
+          return;
+        case FINISHED:
+          throw new VeloxException("InfiniteIterator was closed by user");
+        default:
+          throw new IllegalStateException("Unknown state: " + state);
+      }
+    }
+
+    @Override
+    public RowVector get() {
+      if (!isAvailable) {
+        throw new VeloxException("AsInfiniteIterator#get can only be called after #available() returns true");
+      }
+      final RowVector rv = upIterator.get();
+      isAvailable = false;
+      return rv;
     }
 
     @Override

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -32,6 +32,7 @@ import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.query.QueryExecutor;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.SampleQueryTests;
+import io.github.zhztheplayer.velox4j.test.TestThreads;
 import io.github.zhztheplayer.velox4j.test.UpIteratorTests;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.DoubleType;
@@ -221,7 +222,7 @@ public class JniApiTest {
     final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
     final ExternalStream es = jniApi.newExternalStream(down);
     final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);
-    final Thread thread = new Thread(new Runnable() {
+    final Thread thread = TestThreads.newTestThread(new Runnable() {
       @Override
       public void run() {
         SampleQueryTests.assertIterator(up);

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -288,7 +288,7 @@ public class QueryTest {
   }
 
   @Test
-  public void testExternalStreamFromBlockingQueueWithInfiniteIteratorOut() throws InterruptedException {
+  public void testExternalStreamFromBlockingQueueWithInfiniteIteratorOut() throws Exception {
     final BlockingQueue<RowVector> queue = new LinkedBlockingQueue<>();
     final DownIterator down = DownIterators.fromBlockingQueue(queue);
     final ExternalStream es = session.externalStreamOps().bind(down);

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/TestThreads.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/TestThreads.java
@@ -1,0 +1,11 @@
+package io.github.zhztheplayer.velox4j.test;
+
+import com.google.common.util.concurrent.UncaughtExceptionHandlers;
+
+public final class TestThreads {
+  public static Thread newTestThread(Runnable target) {
+    final Thread t = new Thread(target);
+    t.setUncaughtExceptionHandler(UncaughtExceptionHandlers.systemExit());
+    return t;
+  }
+}


### PR DESCRIPTION
An enhancement for the feature added in https://github.com/velox4j/velox4j/pull/170.

The `InfiniteIterator<RowVector>` has the following APIs:

1. `boolean available()`: Returns whether the iterator has new output data. Non-blocking. 
2. `void waitFor()` Blocking-wait until the iterator has new output data or gets closed by user.
3. `RowVector get()`: Get the latest row vector from the iterator.