### PR TITLE
Add C++ side queue-based external stream to ease reference handling of row vectors from Java code

### DIFF
--- a/src/main/cpp/main/CMakeLists.txt
+++ b/src/main/cpp/main/CMakeLists.txt
@@ -22,6 +22,7 @@ set(VELOX4J_SOURCES
         velox4j/init/Config.cc
         velox4j/eval/Evaluation.cc
         velox4j/eval/Evaluator.cc
+        velox4j/iterator/BlockingQueue.cc
 )
 set(VELOX4J_INCLUDES
         ${CMAKE_CURRENT_LIST_DIR}

--- a/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
+++ b/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
@@ -1,0 +1,111 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BlockingQueue.h"
+
+namespace velox4j {
+using namespace facebook::velox;
+
+BlockingQueue::BlockingQueue() {
+  waitExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(1);
+}
+
+BlockingQueue::~BlockingQueue() {
+  close();
+}
+
+std::optional<RowVectorPtr> BlockingQueue::read(
+    ContinueFuture& future) {
+  {
+    std::unique_lock lock(mutex_);
+
+    if (!queue_.empty()) {
+      auto rowVector = queue_.front();
+      queue_.pop();
+      return rowVector;
+    }
+  }
+
+  // Blocked. Async wait for a new element.
+  auto [readPromise, readFuture] =
+      makeVeloxContinuePromiseContract(
+          fmt::format("BlockingQueue::read"));
+  // Returns a future that is fulfilled immediately to signal Velox
+  // that this stream is still open and is currently waiting for input.
+  future = std::move(readFuture);
+  {
+    std::lock_guard l(mutex_);
+    VELOX_CHECK(promises_.empty());
+    promises_.emplace_back(std::move(readPromise));
+  }
+
+  waitExecutor_->add([this]() -> void {
+    std::unique_lock lock(mutex_);
+    // Async wait for a new element.
+    condVar_.wait(lock, [this]() { return closed_ || !queue_.empty(); });
+    if (closed_) {
+      try {
+        VELOX_FAIL("BlockingQueue was just closed");
+      } catch (const std::exception& e) {
+        // Velox should guarantee the continue future is only requested once
+        // while it's not fulfilled.
+        VELOX_CHECK(promises_.size() == 1);
+        for (auto& p : promises_) {
+          p.setException(e);
+          promises_.clear();
+          return;
+        }
+      }
+    }
+    VELOX_CHECK(!queue_.empty());
+    VELOX_CHECK(promises_.size() == 1);
+    for (auto& p : promises_) {
+      p.setValue();
+    }
+    promises_.clear();
+  });
+
+  return std::nullopt;
+}
+
+void BlockingQueue::put(RowVectorPtr rowVector) {
+  {
+    std::lock_guard lock(mutex_);
+    queue_.push(std::move(rowVector));
+  }
+  condVar_.notify_one();
+}
+
+bool BlockingQueue::empty() const {
+  {
+    std::lock_guard lock(mutex_);
+    return queue_.empty();
+  }
+}
+
+void BlockingQueue::close() {
+  {
+    std::lock_guard lock(mutex_);
+    bool expected = false;
+    if (!closed_.compare_exchange_strong(expected, true)) {
+      return;
+    }
+  }
+  condVar_.notify_one();
+  waitExecutor_->join();
+}
+} // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -21,6 +21,7 @@
 #include <velox/core/PlanNode.h>
 #include <velox/exec/TableWriter.h>
 #include <velox/vector/VectorSaver.h>
+
 #include "JniCommon.h"
 #include "JniError.h"
 #include "velox4j/arrow/Arrow.h"
@@ -29,6 +30,7 @@
 #include "velox4j/iterator/DownIterator.h"
 #include "velox4j/lifecycle/Session.h"
 #include "velox4j/query/QueryExecutor.h"
+#include "velox4j/iterator/BlockingQueue.h"
 
 namespace velox4j {
 using namespace facebook::velox;
@@ -102,10 +104,17 @@ jlong upIteratorGet(JNIEnv* env, jobject javaThis, jlong itrId) {
   JNI_METHOD_END(-1L)
 }
 
-jlong newExternalStream(JNIEnv* env, jobject javaThis, jobject itrRef) {
+jlong createExternalStreamFromDownIterator(JNIEnv* env, jobject javaThis, jobject itrRef) {
   JNI_METHOD_START
   auto es = std::make_shared<DownIterator>(env, itrRef);
   return sessionOf(env, javaThis)->objectStore()->save(es);
+  JNI_METHOD_END(-1L)
+}
+
+jlong createBlockingQueue(JNIEnv* env, jobject javaThis) {
+  JNI_METHOD_START
+  auto queue = std::make_shared<BlockingQueue>();
+  return sessionOf(env, javaThis)->objectStore()->save(queue);
   JNI_METHOD_END(-1L)
 }
 
@@ -342,10 +351,15 @@ void JniWrapper::initialize(JNIEnv* env) {
   addNativeMethod(
       "upIteratorGet", (void*)upIteratorGet, kTypeLong, kTypeLong, nullptr);
   addNativeMethod(
-      "newExternalStream",
-      (void*)newExternalStream,
+      "createExternalStreamFromDownIterator",
+      (void*)createExternalStreamFromDownIterator,
       kTypeLong,
       "io/github/zhztheplayer/velox4j/iterator/DownIterator",
+      nullptr);
+  addNativeMethod(
+      "createBlockingQueue",
+      (void*)createBlockingQueue,
+      kTypeLong,
       nullptr);
   addNativeMethod(
       "createEmptyBaseVector",

--- a/src/main/cpp/test/CMakeLists.txt
+++ b/src/main/cpp/test/CMakeLists.txt
@@ -26,7 +26,14 @@ add_test(velox4j_query_serde_test velox4j_query_serde_test)
 
 add_executable(velox4j_query_test
         ${TEST_OBJECT_FILES}
-        velox4j/query/QueryTest.cpp
+        velox4j/query/QueryTest.cc
 )
 target_link_libraries(velox4j_query_test velox4j_test)
 add_test(velox4j_query_test velox4j_query_test)
+
+add_executable(velox4j_blocking_queue_test
+        ${TEST_OBJECT_FILES}
+        velox4j/iterator/BlockingQueueTest.cc
+)
+target_link_libraries(velox4j_blocking_queue_test velox4j_test)
+add_test(velox4j_blocking_queue_test velox4j_blocking_queue_test)

--- a/src/main/cpp/test/velox4j/iterator/BlockingQueueTest.cc
+++ b/src/main/cpp/test/velox4j/iterator/BlockingQueueTest.cc
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox4j/iterator/BlockingQueue.h"
+#include <gtest/gtest.h>
+#include <velox/vector/tests/utils/VectorTestBase.h>
+#include "velox4j/test/Init.h"
+
+namespace velox4j {
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+class BlockingQueueTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    testingEnsureInitializedForSpark();
+  }
+
+  BlockingQueueTest() {
+    data_ = {
+        makeRowVector({
+            makeFlatVector<int64_t>({1, 2, 3}),
+            makeFlatVector<int32_t>({10, 20, 30}),
+            makeConstant(true, 3),
+        }),
+        makeRowVector({
+            makeFlatVector<int64_t>({2, 3, 4, 5}),
+            makeFlatVector<int32_t>({20, 30, 40, 50}),
+            makeConstant(false, 4),
+        })};
+  }
+
+  std::vector<RowVectorPtr> data_;
+};
+
+TEST_F(BlockingQueueTest, sanity) {
+  BlockingQueue queue;
+
+  // Put data into the queue.
+  for (auto& row : data_) {
+    queue.put(row);
+  }
+
+  // Read the data back.
+  for (auto& expectedRow : data_) {
+    facebook::velox::ContinueFuture future;
+    auto result = queue.read(future);
+    ASSERT_FALSE(!future.valid());
+    ASSERT_EQ(result.value()->size(), expectedRow->size());
+  }
+
+  ASSERT_TRUE(queue.empty());
+}
+
+TEST_F(BlockingQueueTest, concurrentPutAndRead) {
+  velox4j::BlockingQueue queue;
+  const int numIterations = 10;
+
+  // Consumer thread.
+  std::thread consumer([&]() {
+    for (int i = 0; i < numIterations; ++i) {
+      for (auto& expectedRow : data_) {
+        while (true) {
+          facebook::velox::ContinueFuture future = ContinueFuture::makeEmpty();
+          auto result = queue.read(future);
+          if (future.valid()) {
+            future.wait();
+            continue;
+          }
+          ASSERT_EQ(result.value()->size(), expectedRow->size());
+          break;
+        }
+      }
+    }
+  });
+
+  // Producer thread.
+  std::thread producer([&]() {
+    for (int i = 0; i < numIterations; ++i) {
+      // Put data into the queue.
+      for (auto& row : data_) {
+        // Insert some delay to block the consumer thread.
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        queue.put(row);
+      }
+    }
+  });
+
+  producer.join();
+  consumer.join();
+  ASSERT_TRUE(queue.empty());
+}
+} // namespace velox4j

--- a/src/main/cpp/test/velox4j/query/QueryTest.cc
+++ b/src/main/cpp/test/velox4j/query/QueryTest.cc
@@ -66,8 +66,9 @@ class QueryTest : public testing::Test, public test::VectorTestBase {
       switch (state) {
         case UpIterator::State::AVAILABLE: {
           const auto rv = itr.get();
-          out.push_back(std::dynamic_pointer_cast<RowVector>(
-              RowVector::loadedVectorShared(rv)));
+          out.push_back(
+              std::dynamic_pointer_cast<RowVector>(
+                  RowVector::loadedVectorShared(rv)));
           break;
         }
         case UpIterator::State::BLOCKED:
@@ -82,7 +83,8 @@ class QueryTest : public testing::Test, public test::VectorTestBase {
 
   exec::Split makeFuzzerSplit(size_t numRows) const {
     return exec::Split(
-        std::make_shared<connector::fuzzer::FuzzerConnectorSplit>(kFuzzerConnectorId, numRows));
+        std::make_shared<connector::fuzzer::FuzzerConnectorSplit>(
+            kFuzzerConnectorId, numRows));
   }
 
   std::vector<exec::Split> makeFuzzerSplits(

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/ExternalStream.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/ExternalStream.java
@@ -2,15 +2,5 @@ package io.github.zhztheplayer.velox4j.connector;
 
 import io.github.zhztheplayer.velox4j.jni.CppObject;
 
-public class ExternalStream implements CppObject {
-  private final long id;
-
-  public ExternalStream(long id) {
-    this.id = id;
-  }
-
-  @Override
-  public long id() {
-    return id;
-  }
+public interface ExternalStream extends CppObject {
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/ExternalStreams.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/ExternalStreams.java
@@ -1,7 +1,10 @@
 package io.github.zhztheplayer.velox4j.connector;
 
+import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.iterator.DownIterator;
+import io.github.zhztheplayer.velox4j.jni.CppObject;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
+import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
 
 public class ExternalStreams {
   private final JniApi jniApi;
@@ -11,6 +14,40 @@ public class ExternalStreams {
   }
 
   public ExternalStream bind(DownIterator itr) {
-    return jniApi.newExternalStream(itr);
+    return jniApi.createExternalStreamFromDownIterator(itr);
+  }
+
+  public BlockingQueue newBlockingQueue() {
+    return jniApi.createBlockingQueue();
+  }
+
+  public static class GenericExternalStream implements ExternalStream {
+    private final long id;
+
+    public GenericExternalStream(long id) {
+      this.id = id;
+    }
+
+    @Override
+    public long id() {
+      return id;
+    }
+  }
+
+  public static class BlockingQueue implements ExternalStream {
+    private final long id;
+
+    public BlockingQueue(long id) {
+      this.id = id;
+    }
+
+    @Override
+    public long id() {
+      return id;
+    }
+
+    public void put(RowVector rowVector) {
+      StaticJniApi.get().blockingQueuePut(this, rowVector);
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/DownIterator.java
@@ -20,15 +20,14 @@ public interface DownIterator {
   }
 
   @CalledFromNative
-  default int advance() {
-      return advance0().getId();
-  }
+  int advance();
+
   @CalledFromNative
   void waitFor() throws InterruptedException;
+
   @CalledFromNative
   long get();
+
   @CalledFromNative
   void close();
-
-  State advance0();
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -2,6 +2,7 @@ package io.github.zhztheplayer.velox4j.jni;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.github.zhztheplayer.velox4j.connector.ExternalStream;
+import io.github.zhztheplayer.velox4j.connector.ExternalStreams;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.data.SelectivityVector;
@@ -68,8 +69,12 @@ public final class JniApi {
     return baseVectorWrap(jni.upIteratorGet(itr.id())).asRowVector();
   }
 
-  public ExternalStream newExternalStream(DownIterator itr) {
-    return new ExternalStream(jni.newExternalStream(itr));
+  public ExternalStream createExternalStreamFromDownIterator(DownIterator itr) {
+    return new ExternalStreams.GenericExternalStream(jni.createExternalStreamFromDownIterator(itr));
+  }
+
+  public ExternalStreams.BlockingQueue createBlockingQueue() {
+    return new ExternalStreams.BlockingQueue(jni.createBlockingQueue());
   }
 
   public BaseVector createEmptyBaseVector(Type type) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -45,7 +45,8 @@ final class JniWrapper {
   native long upIteratorGet(long id);
 
   // For DownIterator.
-  native long newExternalStream(DownIterator itr);
+  native long createExternalStreamFromDownIterator(DownIterator itr);
+  native long createBlockingQueue();
 
   // For BaseVector / RowVector / SelectivityVector.
   native long createEmptyBaseVector(String typeJson);

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -2,7 +2,9 @@ package io.github.zhztheplayer.velox4j.jni;
 
 import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.connector.ConnectorSplit;
+import io.github.zhztheplayer.velox4j.connector.ExternalStreams;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
+import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.data.SelectivityVector;
 import io.github.zhztheplayer.velox4j.data.VectorEncoding;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
@@ -56,6 +58,10 @@ public class StaticJniApi {
 
   public void upIteratorWait(UpIterator itr) {
     jni.upIteratorWait(itr.id());
+  }
+
+  public void blockingQueuePut(ExternalStreams.BlockingQueue queue, RowVector rowVector) {
+    jni.blockingQueuePut(queue.id(), rowVector.id());
   }
 
   public void serialTaskAddSplit(SerialTask serialTask, String planNodeId, int groupId,

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -26,6 +26,9 @@ public class StaticJniWrapper {
   native int upIteratorAdvance(long id);
   native void upIteratorWait(long id);
 
+  // For DownIterator.
+  native void blockingQueuePut(long id, long rvId);
+
   // For SerialTask.
   native void serialTaskAddSplit(long id, String planNodeId, int groupId, String connectorSplitJson);
   native void serialTaskNoMoreSplits(long id, String planNodeId);

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -206,7 +206,7 @@ public class JniApiTest {
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
     final UpIterator itr = queryExecutor.execute();
     final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
-    final ExternalStream es = jniApi.newExternalStream(down);
+    final ExternalStream es = jniApi.createExternalStreamFromDownIterator(down);
     final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);
     SampleQueryTests.assertIterator(up);
     session.close();
@@ -220,7 +220,7 @@ public class JniApiTest {
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
     final UpIterator itr = queryExecutor.execute();
     final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
-    final ExternalStream es = jniApi.newExternalStream(down);
+    final ExternalStream es = jniApi.createExternalStreamFromDownIterator(down);
     final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);
     final Thread thread = TestThreads.newTestThread(new Runnable() {
       @Override


### PR DESCRIPTION
New API to create a C++ side queue-based external stream:

```java
final ExternalStreams.BlockingQueue queue = session.externalStreamOps().newBlockingQueue();
final ConnectorSplit split = new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
```

With the new queue API, user can choose to close the row vector immediately after adding to the queue:

```java
queue.put(rv);
rv.close();
```

As a break-down, `queue.put(rv)` will pass `rv` to C++ and save to the C++ side blocking queue. After finishing, `rv.close()` can be safely invoked to release the Java-side reference to the row vector. The blocking queue will still hold the row vector in C++ side with smart pointer. 

This implementation will replace `DownIterators#fromBlockingQueue`. The latter will be removed in the next PR.