### PR TITLE
Add API `ExternalStreams.BlockingQueue#noMoreInput`

### DIFF
--- a/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
+++ b/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
@@ -1,5 +1,5 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
@@ -58,8 +58,7 @@ std::optional<RowVectorPtr> BlockingQueue::read(ContinueFuture& future) {
 
   // Blocked. Async wait for a new element.
   auto [readPromise, readFuture] =
-      makeVeloxContinuePromiseContract(
-          fmt::format("BlockingQueue::read"));
+      makeVeloxContinuePromiseContract(fmt::format("BlockingQueue::read"));
   // Returns a future that is fulfilled immediately to signal Velox
   // that this stream is still open and is currently waiting for input.
   future = std::move(readFuture);
@@ -74,9 +73,11 @@ std::optional<RowVectorPtr> BlockingQueue::read(ContinueFuture& future) {
     // Async wait for a new element.
     condVar_.wait(lock, [this]() { return state_ != OPEN || !queue_.empty(); });
     switch (state_) {
-      case OPEN:
-      case FINISHED: {
+      case OPEN: {
         VELOX_CHECK(!queue_.empty());
+        // Fall through.
+      }
+      case FINISHED: {
         VELOX_CHECK(promises_.size() == 1);
         for (auto& p : promises_) {
           p.setValue();
@@ -131,7 +132,10 @@ bool BlockingQueue::empty() const {
 }
 
 void BlockingQueue::ensureOpen() const {
-  VELOX_CHECK(state_ == OPEN, "Queue is not open. Current state is {}", stateToString(state_));
+  VELOX_CHECK(
+      state_ == OPEN,
+      "Queue is not open. Current state is {}",
+      stateToString(state_));
 }
 
 void BlockingQueue::ensureNotClosed() const {

--- a/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
+++ b/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
@@ -20,6 +20,18 @@
 namespace velox4j {
 using namespace facebook::velox;
 
+std::string BlockingQueue::stateToString(State state) {
+  switch (state) {
+    case OPEN:
+      return "OPEN";
+    case FINISHED:
+      return "FINISHED";
+    case CLOSED:
+      return "CLOSED";
+  }
+  VELOX_FAIL("unknown state");
+}
+
 BlockingQueue::BlockingQueue() {
   waitExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(1);
 }
@@ -119,11 +131,11 @@ bool BlockingQueue::empty() const {
 }
 
 void BlockingQueue::ensureOpen() const {
-  VELOX_CHECK(state_ == OPEN, "Queue is not open");
+  VELOX_CHECK(state_ == OPEN, "Queue is not open. Current state is {}", stateToString(state_));
 }
 
 void BlockingQueue::ensureNotClosed() const {
-  VELOX_CHECK(state_ != CLOSED, "Queue was closed");
+  VELOX_CHECK(state_ != CLOSED, "Queue was closed.");
 }
 
 void BlockingQueue::close() {

--- a/src/main/cpp/main/velox4j/iterator/BlockingQueue.h
+++ b/src/main/cpp/main/velox4j/iterator/BlockingQueue.h
@@ -30,6 +30,8 @@ class BlockingQueue : public ExternalStream {
    CLOSED = 2
   };
 
+ static std::string stateToString(State state);
+
   // CTOR.
   BlockingQueue();
 

--- a/src/main/cpp/main/velox4j/iterator/BlockingQueue.h
+++ b/src/main/cpp/main/velox4j/iterator/BlockingQueue.h
@@ -24,6 +24,12 @@ namespace velox4j {
 
 class BlockingQueue : public ExternalStream {
  public:
+  enum State {
+   OPEN = 0,
+   FINISHED = 1,
+   CLOSED = 2
+  };
+
   // CTOR.
   BlockingQueue();
 
@@ -41,9 +47,15 @@ class BlockingQueue : public ExternalStream {
 
   void put(facebook::velox::RowVectorPtr rowVector);
 
+  void noMoreInput();
+
   bool empty() const;
 
  private:
+  void ensureOpen() const;
+
+  void ensureNotClosed() const;
+
   void close();
 
   mutable std::mutex mutex_;
@@ -51,6 +63,6 @@ class BlockingQueue : public ExternalStream {
   std::queue<facebook::velox::RowVectorPtr> queue_;
   std::unique_ptr<folly::IOThreadPoolExecutor> waitExecutor_;
   std::vector<facebook::velox::ContinuePromise> promises_{};
-  std::atomic_bool closed_{false};
+  State state_{OPEN};
 };
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -91,6 +91,13 @@ void blockingQueuePut(JNIEnv* env, jobject javaThis, jlong queueId, jlong rvId) 
   JNI_METHOD_END()
 }
 
+void blockingQueueNoMoreInput(JNIEnv* env, jobject javaThis, jlong queueId) {
+  JNI_METHOD_START
+  auto queue = ObjectStore::retrieve<BlockingQueue>(queueId);
+  queue->noMoreInput();
+  JNI_METHOD_END()
+}
+
 void serialTaskAddSplit(
     JNIEnv* env,
     jobject javaThis,
@@ -294,6 +301,8 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       "upIteratorWait", (void*)upIteratorWait, kTypeVoid, kTypeLong, nullptr);
   addNativeMethod(
       "blockingQueuePut", (void*)blockingQueuePut, kTypeVoid, kTypeLong, kTypeLong, nullptr);
+  addNativeMethod(
+      "blockingQueueNoMoreInput", (void*)blockingQueueNoMoreInput, kTypeVoid, kTypeLong, nullptr);
   addNativeMethod(
       "serialTaskAddSplit",
       (void*)serialTaskAddSplit,

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -102,7 +102,7 @@ RowVectorPtr SerialTask::get() {
   VELOX_CHECK(!hasPendingState_);
   VELOX_CHECK_NOT_NULL(
       pending_,
-      "SerialTask: No pending row vector to return.  No pending row vector to return. Make sure the iterator is available via member function advance() first");
+      "SerialTask: No pending row vector to return. Make sure the iterator is available via member function advance() first");
   const auto out = pending_;
   pending_ = nullptr;
   return out;

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/ExternalStreams.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/ExternalStreams.java
@@ -49,5 +49,9 @@ public class ExternalStreams {
     public void put(RowVector rowVector) {
       StaticJniApi.get().blockingQueuePut(this, rowVector);
     }
+
+    public void noMoreInput() {
+      StaticJniApi.get().blockingQueueNoMoreInput(this);
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -64,6 +64,10 @@ public class StaticJniApi {
     jni.blockingQueuePut(queue.id(), rowVector.id());
   }
 
+  public void blockingQueueNoMoreInput(ExternalStreams.BlockingQueue queue) {
+    jni.blockingQueueNoMoreInput(queue.id());
+  }
+
   public void serialTaskAddSplit(SerialTask serialTask, String planNodeId, int groupId,
       ConnectorSplit split) {
     final String splitJson = Serde.toJson(split);

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -28,6 +28,7 @@ public class StaticJniWrapper {
 
   // For DownIterator.
   native void blockingQueuePut(long id, long rvId);
+  native void blockingQueueNoMoreInput(long id);
 
   // For SerialTask.
   native void serialTaskAddSplit(long id, String planNodeId, int groupId, String connectorSplitJson);

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -37,8 +37,6 @@ import org.junit.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 
 public class QueryTest {
@@ -283,6 +281,49 @@ public class QueryTest {
     Assert.assertThrows(VeloxException.class, task::get);
     Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
     Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+  }
+
+
+  @Test
+  public void testBlockingQueueNoMoreInput() throws InterruptedException {
+    final ExternalStreams.BlockingQueue queue = session.externalStreamOps().newBlockingQueue();
+    final TableScanNode scanNode = new TableScanNode(
+        "id-1",
+        SampleQueryTests.getSchema(),
+        new ExternalStreamTableHandle("connector-external-stream"),
+        List.of()
+    );
+    final ConnectorSplit split = new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
+    final Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
+    final SerialTask task = session.queryOps().execute(query);
+    task.addSplit(scanNode.getId(), split);
+    task.noMoreSplits(scanNode.getId());
+    final RowVector rv = BaseVectorTests.newSampleRowVector(session);
+
+    // No input added, the up-iterator is considered blocked.
+    Assert.assertThrows(VeloxException.class, task::get);
+    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+
+    // Add one input.
+    queue.put(rv);
+    task.waitFor();
+    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertThrows(VeloxException.class, task::advance);
+    BaseVectorTests.assertEquals(rv, task.get());
+    Assert.assertThrows(VeloxException.class, task::get);
+    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+
+    // Add another input, then signal no-more-input.
+    queue.put(rv);
+    queue.noMoreInput();
+    task.waitFor();
+    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertThrows(VeloxException.class, task::advance);
+    BaseVectorTests.assertEquals(rv, task.get());
+    Assert.assertEquals(UpIterator.State.FINISHED, task.advance());
+    Assert.assertThrows(VeloxException.class, task::advance);
   }
 
   @Test


### PR DESCRIPTION
Feature separated from https://github.com/velox4j/velox4j/pull/168.

Add API `ExternalStreams.BlockingQueue#noMoreInput`.

Usage:

```java
queue.put(rv);
queue.noMoreInput();
```

Then from the task output side:

```java
Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
task.get(); // Consumes the row vector.
Assert.assertEquals(UpIterator.State.FINISHED, task.advance());
```

This is useful for user to actively end a streaming task from input side.