### PR TITLE
Make plan serializable and source changable

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/InsertTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/InsertTableHandle.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class InsertTableHandle {
+import java.io.Serializable;
+
+public class InsertTableHandle implements Serializable {
   private final String connectorId;
   private final ConnectorInsertTableHandle connectorInsertTableHandle;
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/FilterNode.java
@@ -18,6 +18,7 @@ package io.github.zhztheplayer.velox4j.plan;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
 
 public class FilterNode extends PlanNode {
-  private final List<PlanNode> sources;
+  private List<PlanNode> sources;
   private final TypedExpr filter;
 
   @JsonCreator
@@ -46,5 +47,15 @@ public class FilterNode extends PlanNode {
   @JsonGetter("filter")
   public TypedExpr getFilter() {
     return filter;
+  }
+
+  @Override
+  public void setSources(List<PlanNode> sources) {
+    if (this.sources != null && !this.sources.isEmpty()) {
+      this.sources.forEach(planNode -> planNode.setSources(sources));
+    } else {
+      Preconditions.checkArgument(sources.size() == 1, "Filter only accept one source");
+      this.sources = sources;
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 
 public abstract class PlanNode extends ISerializable {
@@ -38,4 +39,8 @@ public abstract class PlanNode extends ISerializable {
   @JsonGetter("sources")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   protected abstract List<PlanNode> getSources();
+
+  public void setSources(List<PlanNode> sources) {
+    throw new VeloxException("setSources not implemented for " + getClass().getName());
+  }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ProjectNode.java
@@ -18,6 +18,7 @@ package io.github.zhztheplayer.velox4j.plan;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
 
 public class ProjectNode extends PlanNode {
-  private final List<PlanNode> sources;
+  private List<PlanNode> sources;
   private final List<String> names;
   private final List<TypedExpr> projections;
 
@@ -54,5 +55,15 @@ public class ProjectNode extends PlanNode {
   @JsonGetter("projections")
   public List<TypedExpr> getProjections() {
     return projections;
+  }
+
+  @Override
+  public void setSources(List<PlanNode> sources) {
+    if (this.sources != null && !this.sources.isEmpty()) {
+      this.sources.forEach(planNode -> planNode.setSources(sources));
+    } else {
+      Preconditions.checkArgument(sources.size() == 1, "Project only accept one source");
+      this.sources = sources;
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/TableScanNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/TableScanNode.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.github.zhztheplayer.velox4j.connector.Assignment;
 import io.github.zhztheplayer.velox4j.connector.ConnectorTableHandle;
+import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.type.Type;
 
 public class TableScanNode extends PlanNode {
@@ -62,5 +63,10 @@ public class TableScanNode extends PlanNode {
   @Override
   protected List<PlanNode> getSources() {
     return Collections.emptyList();
+  }
+
+  @Override
+  public void setSources(List<PlanNode> sources) {
+    throw new VeloxException("TableScan should not set sources");
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/TableWriteNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/TableWriteNode.java
@@ -18,6 +18,7 @@ package io.github.zhztheplayer.velox4j.plan;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,7 +36,7 @@ public class TableWriteNode extends PlanNode {
   private final boolean hasPartitioningScheme;
   private final RowType outputType;
   private final CommitStrategy commitStrategy;
-  private final List<PlanNode> sources;
+  private List<PlanNode> sources;
 
   @JsonCreator
   public TableWriteNode(
@@ -103,5 +104,15 @@ public class TableWriteNode extends PlanNode {
   @Override
   protected List<PlanNode> getSources() {
     return sources;
+  }
+
+  @Override
+  public void setSources(List<PlanNode> sources) {
+    if (this.sources != null && !this.sources.isEmpty()) {
+      this.sources.forEach(planNode -> planNode.setSources(sources));
+    } else {
+      Preconditions.checkArgument(sources.size() == 1, "TableWrite only accept one source");
+      this.sources = sources;
+    }
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/NativeBean.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/NativeBean.java
@@ -16,4 +16,6 @@
 */
 package io.github.zhztheplayer.velox4j.serde;
 
-public interface NativeBean {}
+import java.io.Serializable;
+
+public interface NativeBean extends Serializable {}


### PR DESCRIPTION
Flink need to chain several PlanNodes together, so a PlanNode may have null source when created, and setSource later.