### PR TITLE
Cleanup static local variables in header files

### DIFF
--- a/src/main/cpp/main/velox4j/jni/JniError.cc
+++ b/src/main/cpp/main/velox4j/jni/JniError.cc
@@ -17,7 +17,8 @@
 #include "JniError.h"
 #include <velox/common/base/Exceptions.h>
 
-void velox4j::JniErrorState::ensureInitialized(JNIEnv* env) {
+namespace velox4j {
+void JniErrorState::ensureInitialized(JNIEnv* env) {
   std::lock_guard<std::mutex> lockGuard(mtx_);
   if (initialized_) {
     return;
@@ -26,7 +27,7 @@ void velox4j::JniErrorState::ensureInitialized(JNIEnv* env) {
   initialized_ = true;
 }
 
-void velox4j::JniErrorState::assertInitialized() const {
+void JniErrorState::assertInitialized() const {
   if (!initialized_) {
     VELOX_FAIL(
         "Fatal: JniErrorState::Initialize(...) was not called before "
@@ -34,22 +35,22 @@ void velox4j::JniErrorState::assertInitialized() const {
   }
 }
 
-jclass velox4j::JniErrorState::runtimeExceptionClass() {
+jclass JniErrorState::runtimeExceptionClass() {
   assertInitialized();
   return runtimeExceptionClass_;
 }
 
-jclass velox4j::JniErrorState::illegalAccessExceptionClass() {
+jclass JniErrorState::illegalAccessExceptionClass() {
   assertInitialized();
   return illegalAccessExceptionClass_;
 }
 
-jclass velox4j::JniErrorState::veloxExceptionClass() {
+jclass JniErrorState::veloxExceptionClass() {
   assertInitialized();
   return veloxExceptionClass_;
 }
 
-void velox4j::JniErrorState::initialize(JNIEnv* env) {
+void JniErrorState::initialize(JNIEnv* env) {
   veloxExceptionClass_ = createGlobalClassReference(
       env, "Lio/github/zhztheplayer/velox4j/exception/VeloxException;");
   ioExceptionClass_ = createGlobalClassReference(env, "Ljava/io/IOException;");
@@ -68,7 +69,7 @@ void velox4j::JniErrorState::initialize(JNIEnv* env) {
   vm_ = vm;
 }
 
-void velox4j::JniErrorState::close() {
+void JniErrorState::close() {
   std::lock_guard<std::mutex> lockGuard(mtx_);
   if (closed_) {
     return;
@@ -82,3 +83,9 @@ void velox4j::JniErrorState::close() {
   env->DeleteGlobalRef(illegalArgumentExceptionClass_);
   closed_ = true;
 }
+
+JniErrorState* getJniErrorState() {
+  static JniErrorState jniErrorState;
+  return &jniErrorState;
+}
+} // namespace velox4j

--- a/src/main/cpp/main/velox4j/jni/JniError.h
+++ b/src/main/cpp/main/velox4j/jni/JniError.h
@@ -42,21 +42,18 @@ class JniErrorState {
  private:
   void initialize(JNIEnv* env);
 
-  jclass ioExceptionClass_ = nullptr;
-  jclass runtimeExceptionClass_ = nullptr;
-  jclass unsupportedOperationExceptionClass_ = nullptr;
-  jclass illegalAccessExceptionClass_ = nullptr;
-  jclass illegalArgumentExceptionClass_ = nullptr;
-  jclass veloxExceptionClass_ = nullptr;
-  JavaVM* vm_;
+  jclass ioExceptionClass_{nullptr};
+  jclass runtimeExceptionClass_{nullptr};
+  jclass unsupportedOperationExceptionClass_{nullptr};
+  jclass illegalAccessExceptionClass_{nullptr};
+  jclass illegalArgumentExceptionClass_{nullptr};
+  jclass veloxExceptionClass_{nullptr};
+  JavaVM* vm_{nullptr};
   bool initialized_{false};
   bool closed_{false};
   std::mutex mtx_;
 };
 
-inline JniErrorState* getJniErrorState() {
-  static JniErrorState jniErrorState;
-  return &jniErrorState;
-}
+JniErrorState* getJniErrorState();
 
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
@@ -41,21 +41,9 @@ constexpr static ObjectHandle kInvalidObjectHandle = -1;
 // manager.
 class ObjectStore {
  public:
-  static ObjectStore* global() {
-    static std::unique_ptr<ObjectStore> globalStore = create();
-    return globalStore.get();
-  }
+  static ObjectStore* global();
 
-  static std::unique_ptr<ObjectStore> create() {
-    static std::mutex mtx;
-    std::lock_guard<std::mutex> lock(mtx);
-    StoreHandle nextId = safeCast<StoreHandle>(stores().nextId());
-    auto store = std::unique_ptr<ObjectStore>(new ObjectStore(nextId));
-    StoreHandle storeId = safeCast<StoreHandle>(stores().insert(store.get()));
-    VELOX_CHECK(
-        storeId == nextId, "Store ID mismatched, this should not happen");
-    return store;
-  }
+  static std::unique_ptr<ObjectStore> create();
 
   static void release(ObjectHandle handle) {
     ResourceHandle storeId =


### PR DESCRIPTION
Otherwise the static variables will be duplicated in different compilation units.