### PR TITLE
Use fully-qualified path for referenced C++ headers

### DIFF
--- a/src/main/cpp/main/velox4j/arrow/Arrow.cc
+++ b/src/main/cpp/main/velox4j/arrow/Arrow.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "Arrow.h"
+#include "velox4j/arrow/Arrow.h"
 #include <velox/vector/arrow/Bridge.h>
 
 namespace velox4j {

--- a/src/main/cpp/main/velox4j/config/Config.cc
+++ b/src/main/cpp/main/velox4j/config/Config.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "Config.h"
+#include "velox4j/config/Config.h"
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/cpp/main/velox4j/connector/ExternalStream.cc
+++ b/src/main/cpp/main/velox4j/connector/ExternalStream.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "ExternalStream.h"
+#include "velox4j/connector/ExternalStream.h"
 
 namespace velox4j {
 using namespace facebook::velox;

--- a/src/main/cpp/main/velox4j/eval/Evaluation.cc
+++ b/src/main/cpp/main/velox4j/eval/Evaluation.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "Evaluation.h"
+#include "velox4j/eval/Evaluation.h"
 
 namespace velox4j {
 using namespace facebook::velox;

--- a/src/main/cpp/main/velox4j/eval/Evaluator.cc
+++ b/src/main/cpp/main/velox4j/eval/Evaluator.cc
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include "Evaluator.h"
-#include "Evaluation.h"
+#include "velox4j/eval/Evaluator.h"
+#include "velox4j/eval/Evaluation.h"
 
 namespace velox4j {
 using namespace facebook::velox;

--- a/src/main/cpp/main/velox4j/init/Config.cc
+++ b/src/main/cpp/main/velox4j/init/Config.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "Config.h"
+#include "velox4j/init/Config.h"
 
 namespace velox4j {
 using namespace facebook::velox;

--- a/src/main/cpp/main/velox4j/init/Init.cc
+++ b/src/main/cpp/main/velox4j/init/Init.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "Init.h"
+#include "velox4j/init/Init.h"
 #include <velox/common/memory/Memory.h>
 #include <velox/connectors/hive/HiveConnector.h>
 #include <velox/connectors/hive/HiveConnectorSplit.h>

--- a/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
+++ b/src/main/cpp/main/velox4j/iterator/BlockingQueue.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "BlockingQueue.h"
+#include "velox4j/iterator/BlockingQueue.h"
 
 namespace velox4j {
 using namespace facebook::velox;

--- a/src/main/cpp/main/velox4j/iterator/DownIterator.cc
+++ b/src/main/cpp/main/velox4j/iterator/DownIterator.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "DownIterator.h"
+#include "velox4j/iterator/DownIterator.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/lifecycle/ObjectStore.h"
 

--- a/src/main/cpp/main/velox4j/iterator/UpIterator.cc
+++ b/src/main/cpp/main/velox4j/iterator/UpIterator.cc
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-#include "UpIterator.h"
+#include "velox4j/iterator/UpIterator.h"

--- a/src/main/cpp/main/velox4j/jni/JniCommon.cc
+++ b/src/main/cpp/main/velox4j/jni/JniCommon.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "JniCommon.h"
+#include "velox4j/jni/JniCommon.h"
 #include <arrow/ipc/reader.h>
 #include <arrow/ipc/writer.h>
 #include <execinfo.h>

--- a/src/main/cpp/main/velox4j/jni/JniError.cc
+++ b/src/main/cpp/main/velox4j/jni/JniError.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "JniError.h"
+#include "velox4j/jni/JniError.h"
 #include <velox/common/base/Exceptions.h>
 
 namespace velox4j {

--- a/src/main/cpp/main/velox4j/jni/JniError.h
+++ b/src/main/cpp/main/velox4j/jni/JniError.h
@@ -19,7 +19,7 @@
 
 #include <stdexcept>
 
-#include "JniCommon.h"
+#include "velox4j/jni/JniCommon.h"
 
 namespace velox4j {
 

--- a/src/main/cpp/main/velox4j/jni/JniLoader.cc
+++ b/src/main/cpp/main/velox4j/jni/JniLoader.cc
@@ -18,11 +18,11 @@
 #include <JniHelpers.h>
 #include <glog/logging.h>
 #include <jni.h>
-#include "JniWrapper.h"
-#include "StaticJniWrapper.h"
 #include "velox4j/iterator/DownIterator.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/jni/JniError.h"
+#include "velox4j/jni/JniWrapper.h"
+#include "velox4j/jni/StaticJniWrapper.h"
 #include "velox4j/memory/JavaAllocationListener.h"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* jvm, void*) {

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-#include "JniWrapper.h"
+#include "velox4j/jni/JniWrapper.h"
 #include <velox/common/encode/Base64.h>
 #include <velox/common/memory/Memory.h>
 #include <velox/core/PlanNode.h>
 #include <velox/exec/TableWriter.h>
 #include <velox/vector/VectorSaver.h>
 
-#include "JniCommon.h"
-#include "JniError.h"
 #include "velox4j/arrow/Arrow.h"
 #include "velox4j/connector/ExternalStream.h"
 #include "velox4j/eval/Evaluator.h"
 #include "velox4j/iterator/BlockingQueue.h"
 #include "velox4j/iterator/DownIterator.h"
+#include "velox4j/jni/JniCommon.h"
+#include "velox4j/jni/JniError.h"
 #include "velox4j/lifecycle/Session.h"
 #include "velox4j/query/QueryExecutor.h"
 

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
-#include "StaticJniWrapper.h"
+#include "velox4j/jni/StaticJniWrapper.h"
 #include <folly/json/json.h>
 #include <velox/common/encode/Base64.h>
 #include <velox/exec/TableWriter.h>
 #include <velox/vector/VectorSaver.h>
 
-#include "JniCommon.h"
-#include "JniError.h"
 #include "velox4j/arrow/Arrow.h"
 #include "velox4j/config/Config.h"
 #include "velox4j/init/Init.h"
 #include "velox4j/iterator/BlockingQueue.h"
 #include "velox4j/iterator/UpIterator.h"
+#include "velox4j/jni/JniCommon.h"
+#include "velox4j/jni/JniError.h"
 #include "velox4j/lifecycle/Session.h"
 #include "velox4j/memory/JavaAllocationListener.h"
 #include "velox4j/query/QueryExecutor.h"

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "ObjectStore.h"
+#include "velox4j/lifecycle/ObjectStore.h"
 #include <glog/logging.h>
 
 namespace velox4j {

--- a/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
+++ b/src/main/cpp/main/velox4j/lifecycle/ObjectStore.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <map>
-#include "ResourceMap.h"
+#include "velox4j/lifecycle/ResourceMap.h"
 
 namespace velox4j {
 

--- a/src/main/cpp/main/velox4j/lifecycle/Session.cc
+++ b/src/main/cpp/main/velox4j/lifecycle/Session.cc
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 
-#include "Session.h"
+#include "velox4j/lifecycle/Session.h"
 
 namespace velox4j {}

--- a/src/main/cpp/main/velox4j/lifecycle/Session.h
+++ b/src/main/cpp/main/velox4j/lifecycle/Session.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <memory>
-#include "ObjectStore.h"
+#include "velox4j/lifecycle/ObjectStore.h"
 #include "velox4j/memory/MemoryManager.h"
 
 namespace velox4j {

--- a/src/main/cpp/main/velox4j/memory/AllocationListener.cc
+++ b/src/main/cpp/main/velox4j/memory/AllocationListener.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "AllocationListener.h"
+#include "velox4j/memory/AllocationListener.h"
 
 namespace velox4j {
 

--- a/src/main/cpp/main/velox4j/memory/ArrowMemoryPool.cc
+++ b/src/main/cpp/main/velox4j/memory/ArrowMemoryPool.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "ArrowMemoryPool.h"
+#include "velox4j/memory/ArrowMemoryPool.h"
 #include <arrow/type_fwd.h>
 #include <velox/common/base/Exceptions.h>
 

--- a/src/main/cpp/main/velox4j/memory/ArrowMemoryPool.h
+++ b/src/main/cpp/main/velox4j/memory/ArrowMemoryPool.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <arrow/memory_pool.h>
-#include "AllocationListener.h"
+#include "velox4j/memory/AllocationListener.h"
 
 namespace velox4j {
 class MemoryAllocator {

--- a/src/main/cpp/main/velox4j/memory/JavaAllocationListener.cc
+++ b/src/main/cpp/main/velox4j/memory/JavaAllocationListener.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "JavaAllocationListener.h"
+#include "velox4j/memory/JavaAllocationListener.h"
 #include <glog/logging.h>
 #include "velox4j/jni/JniCommon.h"
 

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.cc
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.cc
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#include "MemoryManager.h"
-#include "ArrowMemoryPool.h"
+#include "velox4j/memory/MemoryManager.h"
+#include "velox4j/memory/ArrowMemoryPool.h"
 
 namespace velox4j {
 using namespace facebook;

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.h
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.h
@@ -21,8 +21,8 @@
 #include <velox/common/config/Config.h>
 #include <velox/common/memory/Memory.h>
 #include <memory>
-#include "AllocationListener.h"
-#include "ArrowMemoryPool.h"
+#include "velox4j/memory/AllocationListener.h"
+#include "velox4j/memory/ArrowMemoryPool.h"
 
 namespace velox4j {
 

--- a/src/main/cpp/main/velox4j/query/Query.cc
+++ b/src/main/cpp/main/velox4j/query/Query.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "Query.h"
+#include "velox4j/query/Query.h"
 
 #include <velox/exec/PlanNodeStats.h>
 

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "QueryExecutor.h"
+#include "velox4j/query/QueryExecutor.h"
 
 #include <velox/exec/Operator.h>
 #include <velox/exec/PlanNodeStats.h>

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.h
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.h
@@ -19,9 +19,9 @@
 
 #include <velox/exec/TaskStats.h>
 
-#include "Query.h"
 #include "velox4j/iterator/UpIterator.h"
 #include "velox4j/memory/MemoryManager.h"
+#include "velox4j/query/Query.h"
 
 namespace velox4j {
 


### PR DESCRIPTION
A code cleanup.

Synced back from https://github.com/facebookincubator/velox/pull/13186.