### PR TITLE
Make Evaluator accept an Evaluation object as constructor parameter

### DIFF
--- a/src/main/cpp/main/velox4j/arrow/Arrow.cc
+++ b/src/main/cpp/main/velox4j/arrow/Arrow.cc
@@ -30,6 +30,10 @@ void slice(VectorPtr& in) {
   }
   for (auto& child : rowBase->children()) {
     if (child->size() > rowBase->size()) {
+      // Some Velox operations (E.g., Limit) could result in a
+      // RowVector whose children have larger size than itself.
+      // So we perform a slice to keep only the data that is
+      // in real use.
       child = child->slice(0, rowBase->size());
     }
   }

--- a/src/main/cpp/main/velox4j/eval/Evaluator.cc
+++ b/src/main/cpp/main/velox4j/eval/Evaluator.cc
@@ -20,23 +20,18 @@
 
 namespace velox4j {
 using namespace facebook::velox;
-
-Evaluator::Evaluator(MemoryManager* memoryManager, std::string exprJson)
-    : memoryManager_(memoryManager), exprJson_(exprJson) {
+Evaluator::Evaluator(
+    MemoryManager* memoryManager,
+    const std::shared_ptr<const Evaluation>& evaluation)
+    : evaluation_(evaluation) {
   static std::atomic<uint32_t> executionId{0};
   const uint32_t eid = executionId++;
-  auto evaluatorSerdePool = memoryManager_->getVeloxPool(
-      fmt::format("Evaluator Serde Memory Pool - EID {}", std::to_string(eid)),
-      memory::MemoryPool::Kind::kLeaf);
-  auto exprDynamic = folly::parseJson(exprJson_);
-  auto expr =
-      ISerializable::deserialize<Evaluation>(exprDynamic, evaluatorSerdePool);
   queryCtx_ = core::QueryCtx::create(
       nullptr,
-      core::QueryConfig{expr->queryConfig()->toMap()},
-      expr->connectorConfig()->toMap(),
+      core::QueryConfig{evaluation_->queryConfig()->toMap()},
+      evaluation_->connectorConfig()->toMap(),
       cache::AsyncDataCache::getInstance(),
-      memoryManager_
+      memoryManager
           ->getVeloxPool(
               fmt::format(
                   "Evaluator Memory Pool - EID {}", std::to_string(eid)),
@@ -46,11 +41,11 @@ Evaluator::Evaluator(MemoryManager* memoryManager, std::string exprJson)
       fmt::format("Evaluator Context - EID {}", std::to_string(eid)));
   ee_ = std::make_unique<exec::SimpleExpressionEvaluator>(
       queryCtx_.get(),
-      memoryManager_->getVeloxPool(
+      memoryManager->getVeloxPool(
           fmt::format(
               "Evaluator Leaf Memory Pool - EID {}", std::to_string(eid)),
           memory::MemoryPool::Kind::kLeaf));
-  exprSet_ = ee_->compile(expr->expr());
+  exprSet_ = ee_->compile(evaluation_->expr());
 }
 
 VectorPtr Evaluator::eval(

--- a/src/main/cpp/main/velox4j/eval/Evaluator.h
+++ b/src/main/cpp/main/velox4j/eval/Evaluator.h
@@ -21,6 +21,7 @@
 #include <velox/expression/Expr.h>
 #include <velox/vector/BaseVector.h>
 #include <velox/vector/ComplexVector.h>
+#include "velox4j/eval/Evaluation.h"
 #include "velox4j/memory/MemoryManager.h"
 
 namespace velox4j {
@@ -28,15 +29,16 @@ namespace velox4j {
 /// an expression on a set of input row vectors.
 class Evaluator {
  public:
-  Evaluator(MemoryManager* memoryManager, std::string exprJson);
+  Evaluator(
+      MemoryManager* memoryManager,
+      const std::shared_ptr<const Evaluation>& evaluation);
 
   facebook::velox::VectorPtr eval(
       const facebook::velox::SelectivityVector& rows,
       const facebook::velox::RowVector& input);
 
  private:
-  MemoryManager* const memoryManager_;
-  const std::string exprJson_;
+  const std::shared_ptr<const Evaluation>& evaluation_;
   std::shared_ptr<facebook::velox::core::QueryCtx> queryCtx_;
   std::unique_ptr<facebook::velox::core::ExpressionEvaluator> ee_;
   std::unique_ptr<facebook::velox::exec::ExprSet> exprSet_;

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -52,8 +52,13 @@ jlong createEvaluator(JNIEnv* env, jobject javaThis, jstring evalJson) {
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   spotify::jni::JavaString jExprJson{env, evalJson};
+  auto evaluationSerdePool = session->memoryManager()->getVeloxPool(
+      "Evaluation Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
+  auto exprDynamic = folly::parseJson(jExprJson.get());
+  auto evaluation =
+      ISerializable::deserialize<Evaluation>(exprDynamic, evaluationSerdePool);
   auto evaluator =
-      std::make_shared<Evaluator>(session->memoryManager(), jExprJson.get());
+      std::make_shared<Evaluator>(session->memoryManager(), evaluation);
   return sessionOf(env, javaThis)->objectStore()->save(evaluator);
   JNI_METHOD_END(-1L)
 }


### PR DESCRIPTION
This is to allow pre-validation on the expressions `Evaluator` is built on without instantiating a `Evaluator` object.

Synced back from https://github.com/facebookincubator/velox/pull/13186.