### PR TITLE
Add BytesAllocationListener and use it in tests to guard against sanity of the AllocationListenerApi

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/memory/BytesAllocationListener.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/memory/BytesAllocationListener.java
@@ -1,0 +1,41 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.github.zhztheplayer.velox4j.memory;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** An allocation listener that accumulates the allocated bytes with an internal counter. */
+public class BytesAllocationListener implements AllocationListener {
+  private final AtomicLong currentBytes = new AtomicLong(0);
+  private final AtomicLong peakBytes = new AtomicLong(0);
+
+  public BytesAllocationListener() {}
+
+  @Override
+  public void allocationChanged(long diff) {
+    long current = currentBytes.addAndGet(diff);
+    peakBytes.getAndUpdate(prevPeak -> Math.max(prevPeak, current));
+  }
+
+  public long currentBytes() {
+    return currentBytes.get();
+  }
+
+  public long peakBytes() {
+    return peakBytes.get();
+  }
+}

--- a/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
@@ -26,24 +26,27 @@ import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.BaseVectorTests;
 import io.github.zhztheplayer.velox4j.data.RowVector;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 
 public class ArrowTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.session.Session;
@@ -33,18 +33,21 @@ import io.github.zhztheplayer.velox4j.type.RowType;
 import io.github.zhztheplayer.velox4j.type.Type;
 
 public class BaseVectorTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/SelectivityVectorTest.java
@@ -19,24 +19,27 @@ package io.github.zhztheplayer.velox4j.data;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 
 public class SelectivityVectorTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
@@ -29,7 +29,7 @@ import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.data.SelectivityVector;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.ResourceTests;
@@ -37,18 +37,21 @@ import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
 
 public class EvaluationTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -38,7 +38,7 @@ import io.github.zhztheplayer.velox4j.iterator.DownIterator;
 import io.github.zhztheplayer.velox4j.iterator.DownIterators;
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.iterator.UpIterators;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.query.QueryExecutor;
 import io.github.zhztheplayer.velox4j.session.Session;
@@ -54,17 +54,20 @@ import io.github.zhztheplayer.velox4j.variant.IntegerValue;
 import io.github.zhztheplayer.velox4j.variant.RealValue;
 
 public class JniApiTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -40,7 +40,7 @@ import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.iterator.*;
 import io.github.zhztheplayer.velox4j.jni.JniWorkspace;
 import io.github.zhztheplayer.velox4j.join.JoinType;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.*;
 import io.github.zhztheplayer.velox4j.serde.Serde;
@@ -63,13 +63,15 @@ public class QueryTest {
   private static final String HIVE_CONNECTOR_ID = "connector-hive";
   private static TestDataFile NATION_FILE;
   private static TestDataFile REGION_FILE;
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
     NATION_FILE = TpchDatasets.get().get(TpchTableName.NATION);
     REGION_FILE = TpchDatasets.get().get(TpchTableName.REGION);
   }
@@ -77,6 +79,7 @@ public class QueryTest {
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/EvaluationSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/EvaluationSerdeTest.java
@@ -19,6 +19,7 @@ package io.github.zhztheplayer.velox4j.serde;
 import java.util.Collections;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -26,23 +27,26 @@ import io.github.zhztheplayer.velox4j.config.Config;
 import io.github.zhztheplayer.velox4j.config.ConnectorConfig;
 import io.github.zhztheplayer.velox4j.eval.Evaluation;
 import io.github.zhztheplayer.velox4j.expression.CallTypedExpr;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.IntegerType;
 
 public class EvaluationSerdeTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -28,7 +28,7 @@ import io.github.zhztheplayer.velox4j.data.BaseVectorTests;
 import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.join.JoinType;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.plan.AggregationNode;
 import io.github.zhztheplayer.velox4j.plan.FilterNode;
@@ -53,18 +53,21 @@ import io.github.zhztheplayer.velox4j.window.WindowFunction;
 import io.github.zhztheplayer.velox4j.window.WindowType;
 
 public class PlanNodeSerdeTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
@@ -33,7 +33,7 @@ import io.github.zhztheplayer.velox4j.expression.DereferenceTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.InputTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.LambdaTypedExpr;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.session.Session;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
@@ -45,18 +45,21 @@ import io.github.zhztheplayer.velox4j.type.VarCharType;
 import io.github.zhztheplayer.velox4j.variant.IntegerValue;
 
 public class TypedExprSerdeTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before

--- a/src/test/java/io/github/zhztheplayer/velox4j/write/TableWriteTraitsTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/write/TableWriteTraitsTest.java
@@ -19,7 +19,7 @@ package io.github.zhztheplayer.velox4j.write;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
-import io.github.zhztheplayer.velox4j.memory.AllocationListener;
+import io.github.zhztheplayer.velox4j.memory.BytesAllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
 import io.github.zhztheplayer.velox4j.serde.Serde;
 import io.github.zhztheplayer.velox4j.serde.SerdeTests;
@@ -29,18 +29,21 @@ import io.github.zhztheplayer.velox4j.test.Velox4jTests;
 import io.github.zhztheplayer.velox4j.type.RowType;
 
 public class TableWriteTraitsTest {
+  private static BytesAllocationListener allocationListener;
   private static MemoryManager memoryManager;
   private static Session session;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    memoryManager = MemoryManager.create(AllocationListener.NOOP);
+    allocationListener = new BytesAllocationListener();
+    memoryManager = MemoryManager.create(allocationListener);
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
   }
 
   @Before


### PR DESCRIPTION
`BytesAllocationListener` will be used to ensure the sanity of `AllocationListenerApi` API.