### PR TITLE
Remove an unimportant API in SerdeTests

### DIFF
--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/QuerySerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/QuerySerdeTest.java
@@ -34,6 +34,7 @@ public class QuerySerdeTest {
   @Ignore
   public void testReadPlanJsonFromFile() {
     final String queryJson = ResourceTests.readResourceAsString("query/example-1.json");
-    SerdeTests.testISerializableRoundTrip(queryJson, Query.class);
+    final Query query = Serde.fromJson(queryJson, Query.class);
+    SerdeTests.testISerializableRoundTrip(query);
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
@@ -87,12 +87,6 @@ public final class SerdeTests {
     }
   }
 
-  public static <T extends ISerializable> ObjectAndJson<ISerializable> testISerializableRoundTrip(
-      String inJson, Class<? extends T> valueType) {
-    final T inObj = Serde.fromJson(inJson, valueType);
-    return SerdeTests.testISerializableRoundTrip(inObj);
-  }
-
   public static <T extends Variant> ObjectAndJson<Variant> testVariantRoundTrip(T inObj) {
     try (final MemoryManager memoryManager = MemoryManager.create(AllocationListener.NOOP);
         final LocalSession session = JniApiTests.createLocalSession(memoryManager)) {


### PR DESCRIPTION
Remove the API as it is not commonly used in test code.