### PR TITLE
Remove TreeMap member fields in beans to unblock Java-serialization

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/HiveTableHandle.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/HiveTableHandle.java
@@ -19,7 +19,6 @@ package io.github.zhztheplayer.velox4j.connector;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -55,7 +54,7 @@ public class HiveTableHandle extends ConnectorTableHandle {
     this.tableParameters =
         tableParameters == null
             ? Collections.emptyMap()
-            : Collections.unmodifiableSortedMap(new TreeMap<>(tableParameters));
+            : Collections.unmodifiableMap(tableParameters);
   }
 
   @JsonGetter("tableName")

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/MapValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/MapValue.java
@@ -16,14 +16,8 @@
 */
 package io.github.zhztheplayer.velox4j.variant;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -39,14 +33,7 @@ public class MapValue extends Variant {
       this.map = null;
       return;
     }
-    // The following is basically for test code, to write the map values into JSON with a
-    //  comparatively stable order.
-    // TODO: This may cause slow serialization as Variant#toString may be slow.
-    //  A better way is to write reliable Variant#compareTo implementations for all variants.
-    final TreeMap<Variant, Variant> builder =
-        new TreeMap<>(Comparator.comparing(Variant::toString));
-    builder.putAll(map);
-    this.map = Collections.unmodifiableSortedMap(builder);
+    this.map = Collections.unmodifiableMap(map);
   }
 
   @JsonCreator
@@ -73,7 +60,17 @@ public class MapValue extends Variant {
     final int size = map.size();
     final List<Variant> keys = new ArrayList<>(size);
     final List<Variant> values = new ArrayList<>(size);
-    for (Map.Entry<Variant, Variant> entry : map.entrySet()) {
+
+    // The following is basically for test code, to write the map values into JSON with a
+    //  comparatively stable order.
+    // TODO: This may cause slow serialization as Variant#toString may be slow.
+    //  A better way is to write reliable Variant#compareTo implementations for all variants.
+    final List<Map.Entry<Variant, Variant>> sortedEntries =
+        map.entrySet().stream()
+            .sorted(Comparator.comparing(entry -> entry.getKey().toString()))
+            .collect(Collectors.toList());
+
+    for (Map.Entry<Variant, Variant> entry : sortedEntries) {
       keys.add(entry.getKey());
       values.add(entry.getValue());
     }


### PR DESCRIPTION
Unblocks #306. TreeMap is not usually serializable. Remove the usages of it as bean members.