### PR TITLE
Remove optional member fields in beans to unblock Java-serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ public static void main(String[] args) {
       0,
       file.length(),
       Map.of(),
-      OptionalInt.empty(),
-      Optional.empty(),
+      null,
+      null,
       Map.of(),
-      Optional.empty(),
+      null,
       Map.of(),
       Map.of(),
       Map.of(),
-      Optional.empty(),
-      Optional.empty()
+      null,
+      null
   );
   task.addSplit(scanNode.getId(), split);
   task.noMoreSplits(scanNode.getId());

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/FileProperties.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/FileProperties.java
@@ -16,31 +16,34 @@
 */
 package io.github.zhztheplayer.velox4j.connector;
 
-import java.util.OptionalLong;
+import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FileProperties {
-  private final OptionalLong fileSize;
-  private final OptionalLong modificationTime;
+public class FileProperties implements Serializable {
+  private final Long fileSize;
+  private final Long modificationTime;
 
   @JsonCreator
   public FileProperties(
-      @JsonProperty("fileSize") OptionalLong fileSize,
-      @JsonProperty("modificationTime") OptionalLong modificationTime) {
+      @JsonProperty("fileSize") Long fileSize,
+      @JsonProperty("modificationTime") Long modificationTime) {
     this.fileSize = fileSize;
     this.modificationTime = modificationTime;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("fileSize")
-  public OptionalLong getFileSize() {
+  public Long getFileSize() {
     return fileSize;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("modificationTime")
-  public OptionalLong getModificationTime() {
+  public Long getModificationTime() {
     return modificationTime;
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/connector/HiveConnectorSplit.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/connector/HiveConnectorSplit.java
@@ -17,8 +17,6 @@
 package io.github.zhztheplayer.velox4j.connector;
 
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalInt;
 
 import com.fasterxml.jackson.annotation.*;
 import com.google.common.base.Preconditions;
@@ -29,15 +27,15 @@ public class HiveConnectorSplit extends ConnectorSplit {
   private final FileFormat fileFormat;
   private final long start;
   private final long length;
-  private final Map<String, Optional<String>> partitionKeys;
-  private final OptionalInt tableBucketNumber;
-  private final Optional<HiveBucketConversion> bucketConversion;
+  private final Map<String, String> partitionKeys;
+  private final Integer tableBucketNumber;
+  private final HiveBucketConversion bucketConversion;
   private final Map<String, String> customSplitInfo;
-  private final Optional<String> extraFileInfo;
+  private final String extraFileInfo;
   private final Map<String, String> serdeParameters;
   private final Map<String, String> infoColumns;
-  private final Optional<FileProperties> properties;
-  private final Optional<RowIdProperties> rowIdProperties;
+  private final FileProperties properties;
+  private final RowIdProperties rowIdProperties;
 
   @JsonCreator
   public HiveConnectorSplit(
@@ -48,15 +46,15 @@ public class HiveConnectorSplit extends ConnectorSplit {
       @JsonProperty("fileFormat") FileFormat fileFormat,
       @JsonProperty("start") long start,
       @JsonProperty("length") long length,
-      @JsonProperty("partitionKeys") Map<String, Optional<String>> partitionKeys,
-      @JsonProperty("tableBucketNumber") OptionalInt tableBucketNumber,
-      @JsonProperty("bucketConversion") Optional<HiveBucketConversion> bucketConversion,
+      @JsonProperty("partitionKeys") Map<String, String> partitionKeys,
+      @JsonProperty("tableBucketNumber") Integer tableBucketNumber,
+      @JsonProperty("bucketConversion") HiveBucketConversion bucketConversion,
       @JsonProperty("customSplitInfo") Map<String, String> customSplitInfo,
-      @JsonProperty("extraFileInfo") Optional<String> extraFileInfo,
+      @JsonProperty("extraFileInfo") String extraFileInfo,
       @JsonProperty("serdeParameters") Map<String, String> serdeParameters,
       @JsonProperty("infoColumns") Map<String, String> infoColumns,
-      @JsonProperty("properties") Optional<FileProperties> properties,
-      @JsonProperty("rowIdProperties") Optional<RowIdProperties> rowIdProperties) {
+      @JsonProperty("properties") FileProperties properties,
+      @JsonProperty("rowIdProperties") RowIdProperties rowIdProperties) {
     super(connectorId, splitWeight, cacheable);
     this.filePath = Preconditions.checkNotNull(filePath);
     this.fileFormat = Preconditions.checkNotNull(fileFormat);
@@ -104,17 +102,19 @@ public class HiveConnectorSplit extends ConnectorSplit {
   }
 
   @JsonGetter("partitionKeys")
-  public Map<String, Optional<String>> getPartitionKeys() {
+  public Map<String, String> getPartitionKeys() {
     return partitionKeys;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("tableBucketNumber")
-  public OptionalInt getTableBucketNumber() {
+  public Integer getTableBucketNumber() {
     return tableBucketNumber;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("bucketConversion")
-  public Optional<HiveBucketConversion> getBucketConversion() {
+  public HiveBucketConversion getBucketConversion() {
     return bucketConversion;
   }
 
@@ -123,8 +123,9 @@ public class HiveConnectorSplit extends ConnectorSplit {
     return customSplitInfo;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("extraFileInfo")
-  public Optional<String> getExtraFileInfo() {
+  public String getExtraFileInfo() {
     return extraFileInfo;
   }
 
@@ -138,13 +139,15 @@ public class HiveConnectorSplit extends ConnectorSplit {
     return infoColumns;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("properties")
-  public Optional<FileProperties> getProperties() {
+  public FileProperties getProperties() {
     return properties;
   }
 
+  @JsonInclude(JsonInclude.Include.ALWAYS)
   @JsonGetter("rowIdProperties")
-  public Optional<RowIdProperties> getRowIdProperties() {
+  public RowIdProperties getRowIdProperties() {
     return rowIdProperties;
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java
@@ -35,7 +35,7 @@ public abstract class PlanNode extends ISerializable {
     return id;
   }
 
-  @JsonGetter("sources")
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @JsonGetter("sources")
   protected abstract List<PlanNode> getSources();
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/Serde.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/Serde.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 
@@ -53,7 +52,6 @@ public final class Serde {
     jsonMapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
     jsonMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     jsonMapper.disable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
-    jsonMapper.addModule(new Jdk8Module());
     jsonMapper.addModule(new SimpleModule().setDeserializerModifier(deserializerModifier));
     jsonMapper.addModule(new SimpleModule().setSerializerModifier(serializerModifier));
     return jsonMapper.build();

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/ArrayValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/ArrayValue.java
@@ -38,8 +38,8 @@ public class ArrayValue extends Variant {
     this.array = Collections.unmodifiableList(array);
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public List<Variant> getArray() {
     return array;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/BigIntValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/BigIntValue.java
@@ -31,8 +31,8 @@ public class BigIntValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Long getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/DoubleValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/DoubleValue.java
@@ -31,8 +31,8 @@ public class DoubleValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Double getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/HugeIntValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/HugeIntValue.java
@@ -32,8 +32,8 @@ public class HugeIntValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public BigInteger getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/IntegerValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/IntegerValue.java
@@ -31,8 +31,8 @@ public class IntegerValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Integer getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/MapValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/MapValue.java
@@ -51,8 +51,8 @@ public class MapValue extends Variant {
     return new MapValue(builder);
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Entries getEntries() {
     if (map == null) {
       return null;

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/RealValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/RealValue.java
@@ -31,8 +31,8 @@ public class RealValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Float getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/RowValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/RowValue.java
@@ -37,8 +37,8 @@ public class RowValue extends Variant {
     this.row = Collections.unmodifiableList(row);
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public List<Variant> getRow() {
     return row;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/SmallIntValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/SmallIntValue.java
@@ -31,8 +31,8 @@ public class SmallIntValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Integer getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/TimestampValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/TimestampValue.java
@@ -52,8 +52,8 @@ public class TimestampValue extends Variant {
     return new TimestampValue(null, 0, 0);
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Integer getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/TinyIntValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/TinyIntValue.java
@@ -31,8 +31,8 @@ public class TinyIntValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public Integer getValue() {
     return value;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/VarBinaryValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/VarBinaryValue.java
@@ -42,8 +42,8 @@ public class VarBinaryValue extends Variant {
     return new VarBinaryValue(null);
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public String getBase64() {
     return base64;
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/variant/VarCharValue.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/variant/VarCharValue.java
@@ -31,8 +31,8 @@ public class VarCharValue extends Variant {
     this.value = value;
   }
 
-  @JsonGetter("value")
   @JsonInclude(JsonInclude.Include.ALWAYS)
+  @JsonGetter("value")
   public String getValue() {
     return value;
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -18,7 +18,10 @@ package io.github.zhztheplayer.velox4j.query;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -928,14 +931,14 @@ public class QueryTest {
         0,
         file.length(),
         Map.of(),
-        OptionalInt.empty(),
-        Optional.empty(),
+        null,
+        null,
         Map.of(),
-        Optional.empty(),
+        null,
         Map.of(),
         Map.of(),
-        Optional.empty(),
-        Optional.empty());
+        null,
+        null);
   }
 
   private static TableScanNode newSampleTableScanNode(String planNodeId, RowType outputType) {

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/ConnectorSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/ConnectorSerdeTest.java
@@ -16,8 +16,6 @@
 */
 package io.github.zhztheplayer.velox4j.serde;
 
-import java.util.OptionalLong;
-
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,13 +39,13 @@ public class ConnectorSerdeTest {
 
   @Test
   public void testProperties() {
-    final FileProperties in = new FileProperties(OptionalLong.of(100), OptionalLong.of(50));
+    final FileProperties in = new FileProperties(100L, 50L);
     SerdeTests.testJavaBeanRoundTrip(in);
   }
 
   @Test
   public void testPropertiesWithMissingFields() {
-    final FileProperties in = new FileProperties(OptionalLong.of(100), OptionalLong.empty());
+    final FileProperties in = new FileProperties(100L, null);
     SerdeTests.testJavaBeanRoundTrip(in);
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
@@ -16,7 +16,9 @@
 */
 package io.github.zhztheplayer.velox4j.serde;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -151,25 +153,24 @@ public final class SerdeTests {
         FileFormat.ORC,
         1,
         100,
-        Map.of("key", Optional.of("value")),
-        OptionalInt.of(1),
-        Optional.of(
-            new HiveBucketConversion(
-                1,
-                1,
-                List.of(
-                    new HiveColumnHandle(
-                        "t",
-                        ColumnType.REGULAR,
-                        new IntegerType(),
-                        new IntegerType(),
-                        Collections.emptyList())))),
+        Map.of("key", "value"),
+        1,
+        new HiveBucketConversion(
+            1,
+            1,
+            List.of(
+                new HiveColumnHandle(
+                    "t",
+                    ColumnType.REGULAR,
+                    new IntegerType(),
+                    new IntegerType(),
+                    Collections.emptyList()))),
         Map.of("sk", "sv"),
-        Optional.of("extra"),
+        "extra",
         Map.of("serde_key", "serde_value"),
         Map.of("info_key", "info_value"),
-        Optional.of(new FileProperties(OptionalLong.of(100), OptionalLong.of(50))),
-        Optional.of(new RowIdProperties(5, 10, "UUID-100")));
+        new FileProperties(100L, 50L),
+        new RowIdProperties(5, 10, "UUID-100"));
   }
 
   public static HiveConnectorSplit newSampleHiveSplitWithMissingFields() {
@@ -181,25 +182,24 @@ public final class SerdeTests {
         FileFormat.ORC,
         1,
         100,
-        Map.of("key", Optional.of("value")),
-        OptionalInt.of(1),
-        Optional.of(
-            new HiveBucketConversion(
-                1,
-                1,
-                List.of(
-                    new HiveColumnHandle(
-                        "t",
-                        ColumnType.REGULAR,
-                        new IntegerType(),
-                        new IntegerType(),
-                        Collections.emptyList())))),
+        Map.of("key", "value"),
+        1,
+        new HiveBucketConversion(
+            1,
+            1,
+            List.of(
+                new HiveColumnHandle(
+                    "t",
+                    ColumnType.REGULAR,
+                    new IntegerType(),
+                    new IntegerType(),
+                    Collections.emptyList()))),
         Map.of("sk", "sv"),
-        Optional.empty(),
+        null,
         Map.of("serde_key", "serde_value"),
         Map.of("info_key", "info_value"),
-        Optional.of(new FileProperties(OptionalLong.empty(), OptionalLong.of(50))),
-        Optional.of(new RowIdProperties(5, 10, "UUID-100")));
+        new FileProperties(null, 50L),
+        new RowIdProperties(5, 10, "UUID-100"));
   }
 
   public static ConnectorTableHandle newSampleHiveTableHandle(RowType outputType) {


### PR DESCRIPTION
Optional objects are not serializable in Java. Remove the usage of them as bean members. It's sufficient to use trivial `null` values in Java to represent the absences of properties.

Unblocks #306 