### PR TITLE
Downgrade to Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ of Velox4J at the time. But certainly, contributions are always welcomed if anyo
 The minimum toolchain versions for building Velox4J:
 
 - GCC 11
-- JDK 11
+- JDK 8
 
 ## Releases
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,7 @@
     <skip.cpp.build>false</skip.cpp.build>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <surefire.add-opens.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</surefire.add-opens.argLine>
-    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>11</maven.compiler.release>
+    <java.version>8</java.version>
     <junit.version>4.13.1</junit.version>
     <arrow.version>18.1.0</arrow.version>
     <guava.version>33.4.0-jre</guava.version>
@@ -150,6 +147,14 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.0</version>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/src/main/java/io/github/zhztheplayer/velox4j/config/Config.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/config/Config.java
@@ -24,11 +24,12 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 
 public class Config extends ISerializable {
-  private static final Config EMPTY = new Config(List.of());
+  private static final Config EMPTY = new Config(ImmutableList.of());
   public static final String VELOX4J_INIT_PRESET = "velox4j.init.preset";
   public static final String VELOX4J_INIT_PRESET_SPARK = "0";
   public static final String VELOX4J_INIT_PRESET_FLINK = "1";

--- a/src/main/java/io/github/zhztheplayer/velox4j/config/ConnectorConfig.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/config/ConnectorConfig.java
@@ -24,11 +24,12 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.serializable.ISerializable;
 
 public class ConnectorConfig extends ISerializable {
-  private static final ConnectorConfig EMPTY = new ConnectorConfig(List.of());
+  private static final ConnectorConfig EMPTY = new ConnectorConfig(ImmutableList.of());
 
   public static ConnectorConfig empty() {
     return EMPTY;

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
@@ -19,6 +19,7 @@ package io.github.zhztheplayer.velox4j.data;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
@@ -36,7 +37,7 @@ public class BaseVectors {
   }
 
   public static String serializeOne(BaseVector vector) {
-    return StaticJniApi.get().baseVectorSerialize(List.of(vector));
+    return StaticJniApi.get().baseVectorSerialize(ImmutableList.of(vector));
   }
 
   public BaseVector deserializeOne(String serialized) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/AbstractJoinNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/AbstractJoinNode.java
@@ -19,6 +19,7 @@ package io.github.zhztheplayer.velox4j.plan;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
@@ -43,7 +44,7 @@ public abstract class AbstractJoinNode extends PlanNode {
       PlanNode right,
       RowType outputType) {
     super(id);
-    this.sources = List.of(left, right);
+    this.sources = ImmutableList.of(left, right);
     this.joinType = joinType;
     this.leftKeys = leftKeys;
     this.rightKeys = rightKeys;

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/ValuesNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/ValuesNode.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.data.BaseVectors;
 import io.github.zhztheplayer.velox4j.data.RowVector;
@@ -65,6 +66,6 @@ public class ValuesNode extends PlanNode {
 
   @Override
   protected List<PlanNode> getSources() {
-    return List.of();
+    return ImmutableList.of();
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
@@ -129,7 +129,7 @@ public class PolymorphicDeserializer {
           return bd.withByNameInclusion(
               SerdeRegistry.findKvPairs(beanClass).stream()
                   .map(SerdeRegistry.KvPair::getKey)
-                  .collect(Collectors.toUnmodifiableSet()),
+                  .collect(Collectors.toSet()),
               null);
         }
       }

--- a/src/main/java/io/github/zhztheplayer/velox4j/type/MapType.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/type/MapType.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 public class MapType extends Type {
   private final List<Type> children;
@@ -34,7 +35,7 @@ public class MapType extends Type {
   }
 
   public static MapType create(Type keyType, Type valueType) {
-    return new MapType(List.of(keyType, valueType));
+    return new MapType(ImmutableList.of(keyType, valueType));
   }
 
   @JsonGetter("cTypes")

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/BaseVectorTest.java
@@ -16,8 +16,7 @@
 */
 package io.github.zhztheplayer.velox4j.data;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
@@ -71,7 +70,9 @@ public class BaseVectorTest {
   @Test
   public void testCreateEmpty2() {
     final Type type =
-        new RowType(List.of("foo2", "bar2"), List.of(new IntegerType(), new IntegerType()));
+        new RowType(
+            ImmutableList.of("foo2", "bar2"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
     final BaseVector vector = session.baseVectorOps().createEmpty(type);
     Assert.assertEquals(Serde.toPrettyJson(type), Serde.toPrettyJson(vector.getType()));
     Assert.assertEquals(0, vector.getSize());

--- a/src/test/java/io/github/zhztheplayer/velox4j/data/RowVectorTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/data/RowVectorTest.java
@@ -18,6 +18,7 @@ package io.github.zhztheplayer.velox4j.data;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
@@ -59,13 +60,13 @@ public class RowVectorTest {
   public void testPartitionByKeysSinglePartitionKey() {
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(3, input.getSize());
-    final List<RowVector> out0 = session.rowVectorOps().partitionByKeys(input, List.of(0));
+    final List<RowVector> out0 = session.rowVectorOps().partitionByKeys(input, ImmutableList.of(0));
     Assert.assertEquals(3, out0.size());
     Assert.assertEquals(
         ResourceTests.readResourceAsString("vector-output/partition-by-keys-1.txt"),
         BaseVectors.toString(out0));
 
-    final List<RowVector> out1 = session.rowVectorOps().partitionByKeys(input, List.of(1));
+    final List<RowVector> out1 = session.rowVectorOps().partitionByKeys(input, ImmutableList.of(1));
     Assert.assertEquals(1, out1.size());
     Assert.assertEquals(
         ResourceTests.readResourceAsString("vector-output/partition-by-keys-2.txt"),
@@ -76,7 +77,8 @@ public class RowVectorTest {
   public void testPartitionByKeysMultiplePartitionKeys() {
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
     Assert.assertEquals(3, input.getSize());
-    final List<RowVector> out0 = session.rowVectorOps().partitionByKeys(input, List.of(1, 2));
+    final List<RowVector> out0 =
+        session.rowVectorOps().partitionByKeys(input, ImmutableList.of(1, 2));
     Assert.assertEquals(3, out0.size());
     Assert.assertEquals(
         ResourceTests.readResourceAsString("vector-output/partition-by-keys-3.txt"),

--- a/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/eval/EvaluationTest.java
@@ -16,8 +16,7 @@
 */
 package io.github.zhztheplayer.velox4j.eval;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
@@ -109,7 +108,7 @@ public class EvaluationTest {
         new Evaluation(
             new CallTypedExpr(
                 new BigIntType(),
-                List.of(
+                ImmutableList.of(
                     FieldAccessTypedExpr.create(new BigIntType(), "c0"),
                     FieldAccessTypedExpr.create(new BigIntType(), "a1")),
                 "multiply"),

--- a/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/jni/JniApiTest.java
@@ -19,6 +19,7 @@ package io.github.zhztheplayer.velox4j.jni;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
@@ -156,7 +157,7 @@ public class JniApiTest {
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
     final UpIterator itr = queryExecutor.execute();
     final RowVector vector = UpIteratorTests.collectSingleVector(itr);
-    final List<RowVector> vectors = List.of(vector);
+    final List<RowVector> vectors = ImmutableList.of(vector);
     final String serialized = StaticJniApi.get().baseVectorSerialize(vectors);
     final List<BaseVector> deserialized = jniApi.baseVectorDeserialize(serialized);
     BaseVectorTests.assertEquals(vectors, deserialized);
@@ -172,7 +173,7 @@ public class JniApiTest {
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
     final UpIterator itr = queryExecutor.execute();
     final RowVector vector = UpIteratorTests.collectSingleVector(itr);
-    final List<RowVector> vectors = List.of(vector, vector);
+    final List<RowVector> vectors = ImmutableList.of(vector, vector);
     final String serialized = StaticJniApi.get().baseVectorSerialize(vectors);
     final List<BaseVector> deserialized = jniApi.baseVectorDeserialize(serialized);
     BaseVectorTests.assertEquals(vectors, deserialized);

--- a/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/query/QueryTest.java
@@ -20,11 +20,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
@@ -98,7 +99,8 @@ public class QueryTest {
   @Test
   public void testValuesWith2Steps() {
     final PlanNode values =
-        ValuesNode.create("id-1", List.of(BaseVectorTests.newSampleRowVector(session)), true, 5);
+        ValuesNode.create(
+            "id-1", ImmutableList.of(BaseVectorTests.newSampleRowVector(session)), true, 5);
     final Query query = new Query(values, Config.empty(), ConnectorConfig.empty());
     final QueryExecutor exec = session.queryOps().createQueryExecutor(query);
     final SerialTask task = exec.execute();
@@ -108,7 +110,8 @@ public class QueryTest {
   @Test
   public void testValues() {
     final PlanNode values =
-        ValuesNode.create("id-1", List.of(BaseVectorTests.newSampleRowVector(session)), true, 5);
+        ValuesNode.create(
+            "id-1", ImmutableList.of(BaseVectorTests.newSampleRowVector(session)), true, 5);
     final Query query = new Query(values, Config.empty(), ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
     SampleQueryTests.assertIterator(task, 5);
@@ -158,7 +161,8 @@ public class QueryTest {
     final Query query =
         new Query(
             scanNode,
-            Config.create(Map.of("max_output_batch_rows", String.format("%d", maxOutputBatchRows))),
+            Config.create(
+                ImmutableMap.of("max_output_batch_rows", String.format("%d", maxOutputBatchRows))),
             ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
@@ -191,7 +195,8 @@ public class QueryTest {
     final Query query =
         new Query(
             scanNode,
-            Config.create(Map.of("max_output_batch_rows", String.format("%d", maxOutputBatchRows))),
+            Config.create(
+                ImmutableMap.of("max_output_batch_rows", String.format("%d", maxOutputBatchRows))),
             ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
@@ -271,7 +276,7 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     ;
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", es.id());
@@ -290,7 +295,7 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
     final Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
@@ -339,7 +344,7 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
     final Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
@@ -382,7 +387,7 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
     final Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
@@ -419,7 +424,7 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
     final Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
@@ -495,7 +500,7 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
     final Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
@@ -606,10 +611,10 @@ public class QueryTest {
             "id-1",
             SampleQueryTests.getSchema(),
             new ExternalStreamTableHandle("connector-external-stream"),
-            List.of());
+            ImmutableList.of());
     final FilterNode filterNode =
         new FilterNode(
-            "id-2", List.of(scanNode), ConstantTypedExpr.create(new BooleanValue(false)));
+            "id-2", ImmutableList.of(scanNode), ConstantTypedExpr.create(new BooleanValue(false)));
     final ConnectorSplit split =
         new ExternalStreamConnectorSplit("connector-external-stream", queue.id());
     final Query query = new Query(filterNode, Config.empty(), ConnectorConfig.empty());
@@ -646,9 +651,9 @@ public class QueryTest {
     final ProjectNode projectNode =
         new ProjectNode(
             "id-2",
-            List.of(scanNode),
-            List.of("n_nationkey", "n_comment"),
-            List.of(
+            ImmutableList.of(scanNode),
+            ImmutableList.of("n_nationkey", "n_comment"),
+            ImmutableList.of(
                 FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey"),
                 FieldAccessTypedExpr.create(new VarCharType(), "n_comment")));
     final Query query = new Query(projectNode, Config.empty(), ConnectorConfig.empty());
@@ -671,10 +676,10 @@ public class QueryTest {
     final FilterNode filterNode =
         new FilterNode(
             "id-2",
-            List.of(scanNode),
+            ImmutableList.of(scanNode),
             new CallTypedExpr(
                 new BooleanType(),
-                List.of(
+                ImmutableList.of(
                     FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey"),
                     ConstantTypedExpr.create(new BigIntValue(3L))),
                 "greaterthanorequal"));
@@ -703,14 +708,15 @@ public class QueryTest {
         new HashJoinNode(
             "id-3",
             JoinType.LEFT,
-            List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
-            List.of(FieldAccessTypedExpr.create(new BigIntType(), "r_regionkey")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new BigIntType(), "r_regionkey")),
             null,
             nationScanNode,
             regionScanNode,
             new RowType(
-                List.of("n_nationkey", "n_name", "r_regionkey", "r_name"),
-                List.of(new BigIntType(), new VarCharType(), new BigIntType(), new VarCharType())),
+                ImmutableList.of("n_nationkey", "n_name", "r_regionkey", "r_name"),
+                ImmutableList.of(
+                    new BigIntType(), new VarCharType(), new BigIntType(), new VarCharType())),
             false);
     final Query query = new Query(hashJoinNode, Config.empty(), ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
@@ -734,11 +740,11 @@ public class QueryTest {
     final OrderByNode orderByNode =
         new OrderByNode(
             "id-2",
-            List.of(scanNode),
-            List.of(
+            ImmutableList.of(scanNode),
+            ImmutableList.of(
                 FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey"),
                 FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
-            List.of(new SortOrder(true, false), new SortOrder(false, false)),
+            ImmutableList.of(new SortOrder(true, false), new SortOrder(false, false)),
             false);
     final Query query = new Query(orderByNode, Config.empty(), ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
@@ -757,7 +763,7 @@ public class QueryTest {
     final RowType outputType = NATION_FILE.schema();
     final TableScanNode scanNode = newSampleTableScanNode("id-1", outputType);
     final ConnectorSplit split = newSampleSplit(file);
-    final LimitNode limitNode = new LimitNode("id-2", List.of(scanNode), 5, 3, false);
+    final LimitNode limitNode = new LimitNode("id-2", ImmutableList.of(scanNode), 5, 3, false);
     final Query query = new Query(limitNode, Config.empty(), ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
@@ -839,13 +845,13 @@ public class QueryTest {
     final WindowNode windowNode =
         new WindowNode(
             "id-2",
-            List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
-            List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
-            List.of(new SortOrder(false, true)),
-            List.of("row_num"),
-            List.of(
+            ImmutableList.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
+            ImmutableList.of(new SortOrder(false, true)),
+            ImmutableList.of("row_num"),
+            ImmutableList.of(
                 new WindowFunction(
-                    new CallTypedExpr(new IntegerType(), List.of(), "row_number"),
+                    new CallTypedExpr(new IntegerType(), ImmutableList.of(), "row_number"),
                     new WindowFrame(
                         WindowType.RANGE,
                         BoundType.UNBOUNDED_PRECEDING,
@@ -854,7 +860,7 @@ public class QueryTest {
                         null),
                     false)),
             false,
-            List.of(scanNode));
+            ImmutableList.of(scanNode));
 
     final Query query = new Query(windowNode, Config.empty(), ConnectorConfig.empty());
     final SerialTask task = session.queryOps().execute(query);
@@ -880,7 +886,7 @@ public class QueryTest {
             FileFormat.PARQUET,
             null,
             CompressionKind.GZIP,
-            Map.of(),
+            ImmutableMap.of(),
             true,
             new HiveInsertFileNameGenerator());
     final RowType outputType = TableWriteTraits.outputType();
@@ -895,7 +901,7 @@ public class QueryTest {
             false,
             outputType,
             CommitStrategy.NO_COMMIT,
-            List.of(scanNode));
+            ImmutableList.of(scanNode));
     return tableWriteNode;
   }
 
@@ -906,7 +912,8 @@ public class QueryTest {
       final Type type = rowType.getChildren().get(i);
       list.add(
           new Assignment(
-              name, new HiveColumnHandle(name, ColumnType.REGULAR, type, type, List.of())));
+              name,
+              new HiveColumnHandle(name, ColumnType.REGULAR, type, type, ImmutableList.of())));
     }
     return list;
   }
@@ -916,7 +923,7 @@ public class QueryTest {
     for (int i = 0; i < rowType.size(); i++) {
       final String name = rowType.getNames().get(i);
       final Type type = rowType.getChildren().get(i);
-      list.add(new HiveColumnHandle(name, ColumnType.REGULAR, type, type, List.of()));
+      list.add(new HiveColumnHandle(name, ColumnType.REGULAR, type, type, ImmutableList.of()));
     }
     return list;
   }
@@ -930,13 +937,13 @@ public class QueryTest {
         FileFormat.PARQUET,
         0,
         file.length(),
-        Map.of(),
+        ImmutableMap.of(),
         null,
         null,
-        Map.of(),
+        ImmutableMap.of(),
         null,
-        Map.of(),
-        Map.of(),
+        ImmutableMap.of(),
+        ImmutableMap.of(),
         null,
         null);
   }
@@ -947,7 +954,13 @@ public class QueryTest {
             planNodeId,
             outputType,
             new HiveTableHandle(
-                "connector-hive", "tab-1", false, List.of(), null, outputType, Map.of()),
+                "connector-hive",
+                "tab-1",
+                false,
+                ImmutableList.of(),
+                null,
+                outputType,
+                ImmutableMap.of()),
             toAssignments(outputType));
     return scanNode;
   }
@@ -958,24 +971,25 @@ public class QueryTest {
         new AggregationNode(
             planNodeId,
             AggregateStep.SINGLE,
-            List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
-            List.of(),
-            List.of("cnt"),
-            List.of(
+            ImmutableList.of(FieldAccessTypedExpr.create(new BigIntType(), "n_regionkey")),
+            ImmutableList.of(),
+            ImmutableList.of("cnt"),
+            ImmutableList.of(
                 new Aggregate(
                     new CallTypedExpr(
                         new BigIntType(),
-                        List.of(FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
+                        ImmutableList.of(
+                            FieldAccessTypedExpr.create(new BigIntType(), "n_nationkey")),
                         "sum"),
-                    List.of(new BigIntType()),
+                    ImmutableList.of(new BigIntType()),
                     null,
-                    List.of(),
-                    List.of(),
+                    ImmutableList.of(),
+                    ImmutableList.of(),
                     false)),
             false,
-            List.of(source),
+            ImmutableList.of(source),
             null,
-            List.of());
+            ImmutableList.of());
     return aggregationNode;
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/PlanNodeSerdeTest.java
@@ -16,8 +16,7 @@
 */
 package io.github.zhztheplayer.velox4j.serde;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
@@ -107,7 +106,8 @@ public class PlanNodeSerdeTest {
   public void testValuesNode() {
     // The case fails in debug build. Should investigate.
     final PlanNode values =
-        ValuesNode.create("id-1", List.of(BaseVectorTests.newSampleRowVector(session)), true, 1);
+        ValuesNode.create(
+            "id-1", ImmutableList.of(BaseVectorTests.newSampleRowVector(session)), true, 1);
     SerdeTests.testISerializableRoundTrip(values);
   }
 
@@ -131,9 +131,9 @@ public class PlanNodeSerdeTest {
     final ProjectNode projectNode =
         new ProjectNode(
             "id-2",
-            List.of(scan),
-            List.of("foo"),
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")));
+            ImmutableList.of(scan),
+            ImmutableList.of("foo"),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")));
     SerdeTests.testISerializableRoundTrip(projectNode);
   }
 
@@ -142,7 +142,8 @@ public class PlanNodeSerdeTest {
     final PlanNode scan =
         SerdeTests.newSampleTableScanNode("id-1", SerdeTests.newSampleOutputType());
     final FilterNode filterNode =
-        new FilterNode("id-2", List.of(scan), ConstantTypedExpr.create(new BooleanValue(true)));
+        new FilterNode(
+            "id-2", ImmutableList.of(scan), ConstantTypedExpr.create(new BooleanValue(true)));
     SerdeTests.testISerializableRoundTrip(filterNode);
   }
 
@@ -151,23 +152,27 @@ public class PlanNodeSerdeTest {
     final PlanNode scan1 =
         SerdeTests.newSampleTableScanNode(
             "id-1",
-            new RowType(List.of("foo1", "bar1"), List.of(new IntegerType(), new IntegerType())));
+            new RowType(
+                ImmutableList.of("foo1", "bar1"),
+                ImmutableList.of(new IntegerType(), new IntegerType())));
     final PlanNode scan2 =
         SerdeTests.newSampleTableScanNode(
             "id-2",
-            new RowType(List.of("foo2", "bar2"), List.of(new IntegerType(), new IntegerType())));
+            new RowType(
+                ImmutableList.of("foo2", "bar2"),
+                ImmutableList.of(new IntegerType(), new IntegerType())));
     final PlanNode joinNode =
         new HashJoinNode(
             "id-3",
             JoinType.INNER,
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo1")),
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo2")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo1")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo2")),
             ConstantTypedExpr.create(new BooleanValue(true)),
             scan1,
             scan2,
             new RowType(
-                List.of("foo1", "bar1", "foo2", "bar2"),
-                List.of(
+                ImmutableList.of("foo1", "bar1", "foo2", "bar2"),
+                ImmutableList.of(
                     new IntegerType(), new IntegerType(), new IntegerType(), new IntegerType())),
             false);
     SerdeTests.testISerializableRoundTrip(joinNode);
@@ -180,9 +185,9 @@ public class PlanNodeSerdeTest {
     final OrderByNode orderByNode =
         new OrderByNode(
             "id-2",
-            List.of(scan),
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo1")),
-            List.of(new SortOrder(true, false)),
+            ImmutableList.of(scan),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo1")),
+            ImmutableList.of(new SortOrder(true, false)),
             false);
     SerdeTests.testISerializableRoundTrip(orderByNode);
   }
@@ -191,7 +196,7 @@ public class PlanNodeSerdeTest {
   public void testLimitNode() {
     final PlanNode scan =
         SerdeTests.newSampleTableScanNode("id-1", SerdeTests.newSampleOutputType());
-    final LimitNode limitNode = new LimitNode("id-2", List.of(scan), 5, 3, false);
+    final LimitNode limitNode = new LimitNode("id-2", ImmutableList.of(scan), 5, 3, false);
     SerdeTests.testISerializableRoundTrip(limitNode);
   }
 
@@ -210,7 +215,7 @@ public class PlanNodeSerdeTest {
             true,
             rowType,
             CommitStrategy.TASK_COMMIT,
-            List.of(scan));
+            ImmutableList.of(scan));
     SerdeTests.testISerializableRoundTrip(tableWriteNode);
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/SerdeTests.java
@@ -18,12 +18,12 @@ package io.github.zhztheplayer.velox4j.serde;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
 import org.junit.ComparisonFailure;
@@ -157,14 +157,15 @@ public final class SerdeTests {
             MapType.create(
                 new VarCharType(),
                 new RowType(
-                    List.of("id", "description"), List.of(new BigIntType(), new VarCharType()))));
+                    ImmutableList.of("id", "description"),
+                    ImmutableList.of(new BigIntType(), new VarCharType()))));
     final HiveColumnHandle handle =
         new HiveColumnHandle(
             "complex_type",
             ColumnType.REGULAR,
             dataType,
             dataType,
-            List.of("complex_type[1][\"foo\"].id", "complex_type[2][\"foo\"].id"));
+            ImmutableList.of("complex_type[1][\"foo\"].id", "complex_type[2][\"foo\"].id"));
     return handle;
   }
 
@@ -177,22 +178,22 @@ public final class SerdeTests {
         FileFormat.ORC,
         1,
         100,
-        Map.of("key", "value"),
+        ImmutableMap.of("key", "value"),
         1,
         new HiveBucketConversion(
             1,
             1,
-            List.of(
+            ImmutableList.of(
                 new HiveColumnHandle(
                     "t",
                     ColumnType.REGULAR,
                     new IntegerType(),
                     new IntegerType(),
                     Collections.emptyList()))),
-        Map.of("sk", "sv"),
+        ImmutableMap.of("sk", "sv"),
         "extra",
-        Map.of("serde_key", "serde_value"),
-        Map.of("info_key", "info_value"),
+        ImmutableMap.of("serde_key", "serde_value"),
+        ImmutableMap.of("info_key", "info_value"),
         new FileProperties(100L, 50L),
         new RowIdProperties(5, 10, "UUID-100"));
   }
@@ -206,22 +207,22 @@ public final class SerdeTests {
         FileFormat.ORC,
         1,
         100,
-        Map.of("key", "value"),
+        ImmutableMap.of("key", "value"),
         1,
         new HiveBucketConversion(
             1,
             1,
-            List.of(
+            ImmutableList.of(
                 new HiveColumnHandle(
                     "t",
                     ColumnType.REGULAR,
                     new IntegerType(),
                     new IntegerType(),
                     Collections.emptyList()))),
-        Map.of("sk", "sv"),
+        ImmutableMap.of("sk", "sv"),
         null,
-        Map.of("serde_key", "serde_value"),
-        Map.of("info_key", "info_value"),
+        ImmutableMap.of("serde_key", "serde_value"),
+        ImmutableMap.of("info_key", "info_value"),
         new FileProperties(null, 50L),
         new RowIdProperties(5, 10, "UUID-100"));
   }
@@ -232,10 +233,10 @@ public final class SerdeTests {
             "connector-1",
             "tab-1",
             true,
-            List.of(new SubfieldFilter("complex_type[1].id", new AlwaysTrue())),
+            ImmutableList.of(new SubfieldFilter("complex_type[1].id", new AlwaysTrue())),
             new CallTypedExpr(new BooleanType(), Collections.emptyList(), "always_true"),
             outputType,
-            Map.of("tk", "tv"));
+            ImmutableMap.of("tk", "tv"));
     return handle;
   }
 
@@ -251,27 +252,28 @@ public final class SerdeTests {
     return new HiveBucketProperty(
         HiveBucketProperty.Kind.PRESTO_NATIVE,
         10,
-        List.of("foo", "bar"),
-        List.of(new IntegerType(), new VarCharType()),
-        List.of(
+        ImmutableList.of("foo", "bar"),
+        ImmutableList.of(new IntegerType(), new VarCharType()),
+        ImmutableList.of(
             new HiveSortingColumn("foo", new SortOrder(true, true)),
             new HiveSortingColumn("bar", new SortOrder(false, false))));
   }
 
   public static HiveInsertTableHandle newSampleHiveInsertTableHandle() {
     return new HiveInsertTableHandle(
-        List.of(newSampleHiveColumnHandle()),
+        ImmutableList.of(newSampleHiveColumnHandle()),
         newSampleLocationHandle(),
         FileFormat.PARQUET,
         newSampleHiveBucketProperty(),
         CompressionKind.ZLIB,
-        Map.of("serde_key", "serde_value"),
+        ImmutableMap.of("serde_key", "serde_value"),
         false,
         new HiveInsertFileNameGenerator());
   }
 
   public static RowType newSampleOutputType() {
-    return new RowType(List.of("foo", "bar"), List.of(new IntegerType(), new IntegerType()));
+    return new RowType(
+        ImmutableList.of("foo", "bar"), ImmutableList.of(new IntegerType(), new IntegerType()));
   }
 
   public static PlanNode newSampleTableScanNode(String planNodeId, RowType outputType) {
@@ -288,10 +290,10 @@ public final class SerdeTests {
                 new IntegerType(),
                 Collections.singletonList(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
                 "sum"),
-            List.of(new IntegerType()),
+            ImmutableList.of(new IntegerType()),
             FieldAccessTypedExpr.create(new IntegerType(), "foo"),
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
-            List.of(new SortOrder(true, true)),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
+            ImmutableList.of(new SortOrder(true, true)),
             true);
     return aggregate;
   }
@@ -304,14 +306,14 @@ public final class SerdeTests {
         new AggregationNode(
             aggNodeId,
             AggregateStep.PARTIAL,
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
-            List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
-            List.of("sum"),
-            List.of(aggregate),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
+            ImmutableList.of("sum"),
+            ImmutableList.of(aggregate),
             true,
-            List.of(scan),
+            ImmutableList.of(scan),
             FieldAccessTypedExpr.create(new IntegerType(), "foo"),
-            List.of(0));
+            ImmutableList.of(0));
     return aggregationNode;
   }
 
@@ -339,13 +341,13 @@ public final class SerdeTests {
         new WindowFrame(WindowType.RANGE, BoundType.PRECEDING, null, BoundType.FOLLOWING, null);
     return new WindowNode(
         windowNodeId,
-        List.of(FieldAccessTypedExpr.create(new IntegerType(), "bar")),
-        List.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
-        List.of(new SortOrder(true, false)),
-        List.of("sum_out"),
-        List.of(new WindowFunction(call, frame, true)),
+        ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "bar")),
+        ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "foo")),
+        ImmutableList.of(new SortOrder(true, false)),
+        ImmutableList.of("sum_out"),
+        ImmutableList.of(new WindowFunction(call, frame, true)),
         true,
-        List.of(scan));
+        ImmutableList.of(scan));
   }
 
   public static class ObjectAndJson<T> {

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypeSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypeSerdeTest.java
@@ -16,8 +16,7 @@
 */
 package io.github.zhztheplayer.velox4j.serde;
 
-import java.util.List;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -121,13 +120,16 @@ public class TypeSerdeTest {
   @Test
   public void testRowType() {
     SerdeTests.testISerializableRoundTrip(
-        new RowType(List.of("foo", "bar"), List.of(new IntegerType(), new VarCharType())));
+        new RowType(
+            ImmutableList.of("foo", "bar"),
+            ImmutableList.of(new IntegerType(), new VarCharType())));
   }
 
   @Test
   public void testFunctionType() {
     SerdeTests.testISerializableRoundTrip(
-        FunctionType.create(List.of(new IntegerType(), new VarCharType()), new VarbinaryType()));
+        FunctionType.create(
+            ImmutableList.of(new IntegerType(), new VarCharType()), new VarbinaryType()));
   }
 
   @Test

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/TypedExprSerdeTest.java
@@ -17,8 +17,8 @@
 package io.github.zhztheplayer.velox4j.serde;
 
 import java.util.Collections;
-import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.*;
 
 import io.github.zhztheplayer.velox4j.Velox4j;
@@ -92,7 +92,7 @@ public class TypedExprSerdeTest {
     final CallTypedExpr input2 =
         new CallTypedExpr(new RealType(), Collections.emptyList(), "random_real");
     SerdeTests.testISerializableRoundTrip(
-        ConcatTypedExpr.create(List.of("foo", "bar"), List.of(input1, input2)));
+        ConcatTypedExpr.create(ImmutableList.of("foo", "bar"), ImmutableList.of(input1, input2)));
   }
 
   // Ignored by https://github.com/velox4j/velox4j/issues/104.
@@ -123,7 +123,7 @@ public class TypedExprSerdeTest {
     final CallTypedExpr input2 =
         new CallTypedExpr(new RealType(), Collections.emptyList(), "random_real");
     final ConcatTypedExpr concat =
-        ConcatTypedExpr.create(List.of("foo", "bar"), List.of(input1, input2));
+        ConcatTypedExpr.create(ImmutableList.of("foo", "bar"), ImmutableList.of(input1, input2));
     final DereferenceTypedExpr dereference = DereferenceTypedExpr.create(concat, 1);
     Assert.assertEquals(RealType.class, dereference.getReturnType().getClass());
     SerdeTests.testISerializableRoundTrip(dereference);
@@ -136,7 +136,7 @@ public class TypedExprSerdeTest {
     final CallTypedExpr input2 =
         new CallTypedExpr(new RealType(), Collections.emptyList(), "random_real");
     final ConcatTypedExpr concat =
-        ConcatTypedExpr.create(List.of("foo", "bar"), List.of(input1, input2));
+        ConcatTypedExpr.create(ImmutableList.of("foo", "bar"), ImmutableList.of(input1, input2));
     final FieldAccessTypedExpr fieldAccess = FieldAccessTypedExpr.create(concat, "bar");
     Assert.assertEquals(RealType.class, fieldAccess.getReturnType().getClass());
     SerdeTests.testISerializableRoundTrip(fieldAccess);
@@ -150,7 +150,8 @@ public class TypedExprSerdeTest {
   @Test
   public void testLambdaTypedExpr() {
     final RowType signature =
-        new RowType(List.of("foo", "bar"), List.of(new IntegerType(), new VarCharType()));
+        new RowType(
+            ImmutableList.of("foo", "bar"), ImmutableList.of(new IntegerType(), new VarCharType()));
     final LambdaTypedExpr lambdaTypedExpr =
         LambdaTypedExpr.create(signature, FieldAccessTypedExpr.create(new IntegerType(), "foo"));
     SerdeTests.testISerializableRoundTrip(lambdaTypedExpr);

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
@@ -17,9 +17,9 @@
 package io.github.zhztheplayer.velox4j.serde;
 
 import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -137,9 +137,9 @@ public class VariantSerdeTest {
   @Test
   public void testArrayValue() {
     SerdeTests.testVariantRoundTrip(
-        new ArrayValue(List.of(new IntegerValue(100), new IntegerValue(500))));
+        new ArrayValue(ImmutableList.of(new IntegerValue(100), new IntegerValue(500))));
     SerdeTests.testVariantRoundTrip(
-        new ArrayValue(List.of(new BooleanValue(false), new BooleanValue(true))));
+        new ArrayValue(ImmutableList.of(new BooleanValue(false), new BooleanValue(true))));
     SerdeTests.testVariantRoundTrip(new ArrayValue(null));
   }
 
@@ -147,7 +147,7 @@ public class VariantSerdeTest {
   public void testMapValue() {
     SerdeTests.testVariantRoundTrip(
         new MapValue(
-            Map.of(
+            ImmutableMap.of(
                 new IntegerValue(100), new BooleanValue(false),
                 new IntegerValue(1000), new BooleanValue(true),
                 new IntegerValue(400), new BooleanValue(false),
@@ -160,9 +160,9 @@ public class VariantSerdeTest {
   @Test
   public void testRowValue() {
     SerdeTests.testVariantRoundTrip(
-        new RowValue(List.of(new IntegerValue(100), new BooleanValue(true))));
+        new RowValue(ImmutableList.of(new IntegerValue(100), new BooleanValue(true))));
     SerdeTests.testVariantRoundTrip(
-        new RowValue(List.of(new IntegerValue(500), new BooleanValue(false))));
+        new RowValue(ImmutableList.of(new IntegerValue(500), new BooleanValue(false))));
     SerdeTests.testVariantRoundTrip(new RowValue(null));
   }
 }

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/SampleQueryTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/SampleQueryTests.java
@@ -16,7 +16,7 @@
 */
 package io.github.zhztheplayer.velox4j.test;
 
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.type.BigIntType;
@@ -27,7 +27,8 @@ public final class SampleQueryTests {
   private static final String SAMPLE_QUERY_OUTPUT_PATH = "query-output/example-1.tsv";
   private static final RowType SAMPLE_QUERY_TYPE =
       new RowType(
-          List.of("c0", "a0", "a1"), List.of(new BigIntType(), new BigIntType(), new BigIntType()));
+          ImmutableList.of("c0", "a0", "a1"),
+          ImmutableList.of(new BigIntType(), new BigIntType(), new BigIntType()));
 
   public static RowType getSchema() {
     return SAMPLE_QUERY_TYPE;

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/dataset/tpch/TpchTableName.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/dataset/tpch/TpchTableName.java
@@ -16,7 +16,7 @@
 */
 package io.github.zhztheplayer.velox4j.test.dataset.tpch;
 
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 import io.github.zhztheplayer.velox4j.type.BigIntType;
 import io.github.zhztheplayer.velox4j.type.DecimalType;
@@ -27,13 +27,13 @@ public enum TpchTableName {
   REGION(
       "region/region.parquet",
       new RowType(
-          List.of("r_regionkey", "r_name", "r_comment"),
-          List.of(new BigIntType(), new VarCharType(), new VarCharType()))),
+          ImmutableList.of("r_regionkey", "r_name", "r_comment"),
+          ImmutableList.of(new BigIntType(), new VarCharType(), new VarCharType()))),
 
   CUSTOMER(
       "customer/customer.parquet",
       new RowType(
-          List.of(
+          ImmutableList.of(
               "s_suppkey",
               "s_name",
               "s_address",
@@ -41,7 +41,7 @@ public enum TpchTableName {
               "s_phone",
               "s_acctbal",
               "s_comment"),
-          List.of(
+          ImmutableList.of(
               new BigIntType(),
               new VarCharType(),
               new VarCharType(),
@@ -53,8 +53,9 @@ public enum TpchTableName {
   NATION(
       "nation/nation.parquet",
       new RowType(
-          List.of("n_nationkey", "n_name", "n_regionkey", "n_comment"),
-          List.of(new BigIntType(), new VarCharType(), new BigIntType(), new VarCharType())));
+          ImmutableList.of("n_nationkey", "n_name", "n_regionkey", "n_comment"),
+          ImmutableList.of(
+              new BigIntType(), new VarCharType(), new BigIntType(), new VarCharType())));
 
   private final String relativePath;
   private final RowType schema;


### PR DESCRIPTION
Downgrade to Java 8 to max out compatibility.

This is a trade-off for Velox4J since the performance gains from later JDK is not that important for a JNI library.

We will still bump JDK versions gradually in the future.