### PR TITLE
Downgrade 3rd dependency versions

### DIFF
--- a/.github/workflows/pub-snapshot.yml
+++ b/.github/workflows/pub-snapshot.yml
@@ -37,7 +37,7 @@ jobs:
           key: ut-java-ut-centos7-ccache-${{github.sha}}
           restore-keys: |
             ut-java-ut-centos7-ccache-
-      - name: Run setup script / Build
+      - name: Run setup script / Build and run UTs
         run: |
           docker run -v ${{ github.workspace }}:/velox4j -w / centos:7 bash -c "
             export CCACHE_DIR=/velox4j/.ccache
@@ -45,6 +45,8 @@ jobs:
             cd /velox4j
             bash .github/workflows/scripts/ut-java/setup-centos7.sh
             mvn generate-resources
+            mvn clean test -Dskip.cpp.build=true
+            mvn -P with-newer-deps clean test -Dskip.cpp.build=true
           "
       - name: Set up Java / Maven environment
         uses: actions/setup-java@v4
@@ -57,7 +59,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish package
-        run: mvn -P release --batch-mode deploy -Dskip.cpp.build=true
+        run: mvn -P release --batch-mode clean deploy -Dskip.cpp.build=true
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,11 @@
     <surefire.add-opens.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</surefire.add-opens.argLine>
     <java.version>8</java.version>
     <junit.version>4.13.1</junit.version>
-    <arrow.version>18.1.0</arrow.version>
-    <guava.version>33.4.0-jre</guava.version>
-    <commons-io.version>2.18.0</commons-io.version>
-    <jackson.version>2.18.0</jackson.version>
-    <commons-compress.version>1.27.1</commons-compress.version>
+    <arrow.version>14.0.2</arrow.version>
+    <guava.version>14.0.1</guava.version>
+    <jackson.version>2.13.4</jackson.version>
+    <commons-io.version>2.11.0</commons-io.version>
+    <commons-compress.version>1.21</commons-compress.version>
   </properties>
 
   <dependencies>
@@ -70,10 +70,6 @@
         <exclusion>
           <groupId>com.fasterxml.jackson.datatype</groupId>
           <artifactId>jackson-datatype-jsr310</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -258,7 +254,23 @@
 
   <profiles>
     <profile>
+      <id>with-newer-deps</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <arrow.version>18.1.0</arrow.version>
+        <guava.version>33.4.0-jre</guava.version>
+        <jackson.version>2.18.0</jackson.version>
+        <commons-io.version>2.18.0</commons-io.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
+      </properties>
+    </profile>
+    <profile>
       <id>release</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.StandardSystemProperty;
 
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.resource.ResourceFile;
@@ -34,8 +33,7 @@ public class JniLibLoader {
 
   private static final String LIB_CONTAINER =
       String.format(
-          "velox4j-lib/%s/%s",
-          StandardSystemProperty.OS_NAME.value(), StandardSystemProperty.OS_ARCH.value());
+          "velox4j-lib/%s/%s", System.getProperty("os.name"), System.getProperty("os.arch"));
   private static final Pattern LIB_PATTERN = Pattern.compile("^.+$");
   private static final String VELOX4J_LIB_NAME = "libvelox4j.so";
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
@@ -26,20 +26,7 @@ import org.junit.Test;
 
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
-import io.github.zhztheplayer.velox4j.variant.ArrayValue;
-import io.github.zhztheplayer.velox4j.variant.BigIntValue;
-import io.github.zhztheplayer.velox4j.variant.BooleanValue;
-import io.github.zhztheplayer.velox4j.variant.DoubleValue;
-import io.github.zhztheplayer.velox4j.variant.HugeIntValue;
-import io.github.zhztheplayer.velox4j.variant.IntegerValue;
-import io.github.zhztheplayer.velox4j.variant.MapValue;
-import io.github.zhztheplayer.velox4j.variant.RealValue;
-import io.github.zhztheplayer.velox4j.variant.RowValue;
-import io.github.zhztheplayer.velox4j.variant.SmallIntValue;
-import io.github.zhztheplayer.velox4j.variant.TimestampValue;
-import io.github.zhztheplayer.velox4j.variant.TinyIntValue;
-import io.github.zhztheplayer.velox4j.variant.VarBinaryValue;
-import io.github.zhztheplayer.velox4j.variant.VarCharValue;
+import io.github.zhztheplayer.velox4j.variant.*;
 
 public class VariantSerdeTest {
   @BeforeClass
@@ -147,13 +134,14 @@ public class VariantSerdeTest {
   public void testMapValue() {
     SerdeTests.testVariantRoundTrip(
         new MapValue(
-            ImmutableMap.of(
-                new IntegerValue(100), new BooleanValue(false),
-                new IntegerValue(1000), new BooleanValue(true),
-                new IntegerValue(400), new BooleanValue(false),
-                new IntegerValue(800), new BooleanValue(false),
-                new IntegerValue(200), new BooleanValue(true),
-                new IntegerValue(500), new BooleanValue(true))));
+            ImmutableMap.<Variant, Variant>builder()
+                .put(new IntegerValue(100), new BooleanValue(false))
+                .put(new IntegerValue(1000), new BooleanValue(true))
+                .put(new IntegerValue(400), new BooleanValue(false))
+                .put(new IntegerValue(800), new BooleanValue(false))
+                .put(new IntegerValue(200), new BooleanValue(true))
+                .put(new IntegerValue(500), new BooleanValue(true))
+                .build()));
     SerdeTests.testVariantRoundTrip(new MapValue(null));
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/dataset/tpch/DownloadedTpchDataset.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/dataset/tpch/DownloadedTpchDataset.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
 
@@ -135,7 +135,7 @@ class DownloadedTpchDataset implements TpchDataset {
   private void extractTarGz(Path archive, Path destDir) throws IOException {
     try (GZIPInputStream gis = new GZIPInputStream(Files.newInputStream(archive));
         TarArchiveInputStream tis = new TarArchiveInputStream(gis)) {
-      TarArchiveEntry entry;
+      ArchiveEntry entry;
       while ((entry = tis.getNextEntry()) != null) {
         final Path outPath = destDir.resolve(entry.getName());
         if (entry.isDirectory()) {


### PR DESCRIPTION
Downgrade the 3rd dependency versions to max out compatibility.

User can still specify higher versions and exclude them from Velox4J's dependency list.

The source compatibility with higher versions is protected by a new Maven profile `-P with-newer-deps`.