### PR TITLE
Force using old fashion APIs of Guava to max out compatibility

### DIFF
--- a/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
@@ -46,7 +46,7 @@ public class Velox4j {
    */
   public static void configure(String key, String value) {
     Preconditions.checkNotNull(key, "Key cannot be null");
-    Preconditions.checkNotNull(value, "Value of key %s cannot be null", key);
+    Preconditions.checkNotNull(value, "Value of key %s cannot be null", new Object[] {key});
     synchronized (globalConfMap) {
       if (globalConfMap.containsKey(key)) {
         final String oldValue = Preconditions.checkNotNull(globalConfMap.get(key));

--- a/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/Velox4j.java
@@ -46,7 +46,7 @@ public class Velox4j {
    */
   public static void configure(String key, String value) {
     Preconditions.checkNotNull(key, "Key cannot be null");
-    Preconditions.checkNotNull(value, "Value of key %s cannot be null", new Object[] {key});
+    Preconditions.checkNotNull(value, String.format("Value of key %s cannot be null", key));
     synchronized (globalConfMap) {
       if (globalConfMap.containsKey(key)) {
         final String oldValue = Preconditions.checkNotNull(globalConfMap.get(key));

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
@@ -43,7 +43,7 @@ public class BaseVectors {
   public BaseVector deserializeOne(String serialized) {
     final List<BaseVector> vectors = jniApi.baseVectorDeserialize(serialized);
     Preconditions.checkState(
-        vectors.size() == 1, "Expected one vector, but got %s", new Object[] {vectors.size()});
+        vectors.size() == 1, String.format("Expected one vector, but got %s", vectors.size()));
     return vectors.get(0);
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/BaseVectors.java
@@ -43,7 +43,7 @@ public class BaseVectors {
   public BaseVector deserializeOne(String serialized) {
     final List<BaseVector> vectors = jniApi.baseVectorDeserialize(serialized);
     Preconditions.checkState(
-        vectors.size() == 1, "Expected one vector, but got %s", vectors.size());
+        vectors.size() == 1, "Expected one vector, but got %s", new Object[] {vectors.size()});
     return vectors.get(0);
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/CastTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/CastTypedExpr.java
@@ -36,7 +36,9 @@ public class CastTypedExpr extends TypedExpr {
       @JsonProperty("isTryCast") boolean isTryCast) {
     super(returnType, inputs);
     Preconditions.checkArgument(
-        inputs.size() == 1, "CastTypedExpr should have 1 input, but has %s", inputs.size());
+        inputs.size() == 1,
+        "CastTypedExpr should have 1 input, but has %s",
+        new Object[] {inputs.size()});
     this.isTryCast = isTryCast;
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/CastTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/CastTypedExpr.java
@@ -37,8 +37,7 @@ public class CastTypedExpr extends TypedExpr {
     super(returnType, inputs);
     Preconditions.checkArgument(
         inputs.size() == 1,
-        "CastTypedExpr should have 1 input, but has %s",
-        new Object[] {inputs.size()});
+        String.format("CastTypedExpr should have 1 input, but has %s", inputs.size()));
     this.isTryCast = isTryCast;
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/DereferenceTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/DereferenceTypedExpr.java
@@ -38,7 +38,9 @@ public class DereferenceTypedExpr extends TypedExpr {
     super(returnType, inputs);
     this.index = index;
     Preconditions.checkArgument(
-        inputs.size() == 1, "DereferenceTypedExpr should have 1 input, but has %s", inputs.size());
+        inputs.size() == 1,
+        "DereferenceTypedExpr should have 1 input, but has %s",
+        new Object[] {inputs.size()});
     Preconditions.checkArgument(
         inputs.get(0).getReturnType() instanceof RowType,
         "DereferenceTypedExpr input should be RowType");

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/DereferenceTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/DereferenceTypedExpr.java
@@ -39,8 +39,7 @@ public class DereferenceTypedExpr extends TypedExpr {
     this.index = index;
     Preconditions.checkArgument(
         inputs.size() == 1,
-        "DereferenceTypedExpr should have 1 input, but has %s",
-        new Object[] {inputs.size()});
+        String.format("DereferenceTypedExpr should have 1 input, but has %s", inputs.size()));
     Preconditions.checkArgument(
         inputs.get(0).getReturnType() instanceof RowType,
         "DereferenceTypedExpr input should be RowType");

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/FieldAccessTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/FieldAccessTypedExpr.java
@@ -40,7 +40,7 @@ public class FieldAccessTypedExpr extends TypedExpr {
     Preconditions.checkArgument(
         getInputs().size() <= 1,
         "FieldAccessTypedExpr should have 0 or 1 input, but has %s",
-        getInputs().size());
+        new Object[] {getInputs().size()});
   }
 
   public static FieldAccessTypedExpr create(Type returnType, String fieldName) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/expression/FieldAccessTypedExpr.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/expression/FieldAccessTypedExpr.java
@@ -39,8 +39,8 @@ public class FieldAccessTypedExpr extends TypedExpr {
     this.fieldName = fieldName;
     Preconditions.checkArgument(
         getInputs().size() <= 1,
-        "FieldAccessTypedExpr should have 0 or 1 input, but has %s",
-        new Object[] {getInputs().size()});
+        String.format(
+            "FieldAccessTypedExpr should have 0 or 1 input, but has %s", getInputs().size()));
   }
 
   public static FieldAccessTypedExpr create(Type returnType, String fieldName) {

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
@@ -43,7 +43,8 @@ public interface UpIterator extends CppObject {
     }
 
     public static State get(int id) {
-      Preconditions.checkArgument(STATE_ID_LOOKUP.containsKey(id), "ID not found: %d", id);
+      Preconditions.checkArgument(
+          STATE_ID_LOOKUP.containsKey(id), "ID not found: %d", new Object[] {id});
       return STATE_ID_LOOKUP.get(id);
     }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/iterator/UpIterator.java
@@ -44,7 +44,7 @@ public interface UpIterator extends CppObject {
 
     public static State get(int id) {
       Preconditions.checkArgument(
-          STATE_ID_LOOKUP.containsKey(id), "ID not found: %d", new Object[] {id});
+          STATE_ID_LOOKUP.containsKey(id), String.format("ID not found: %d", id));
       return STATE_ID_LOOKUP.get(id);
     }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
@@ -42,7 +42,7 @@ public class JniLibLoader {
       throw new VeloxException("Libraries were already loaded");
     }
     Preconditions.checkArgument(
-        workDir.isDirectory(), "Work directory %s is not a directory", new Object[] {workDir});
+        workDir.isDirectory(), String.format("Work directory %s is not a directory", workDir));
     final List<ResourceFile> libFiles = Resources.getResources(LIB_CONTAINER, LIB_PATTERN);
     if (libFiles.isEmpty()) {
       throw new VeloxException(

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniLibLoader.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.StandardSystemProperty;
 
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.resource.ResourceFile;
@@ -34,8 +33,7 @@ public class JniLibLoader {
 
   private static final String LIB_CONTAINER =
       String.format(
-          "velox4j-lib/%s/%s",
-          StandardSystemProperty.OS_NAME.value(), StandardSystemProperty.OS_ARCH.value());
+          "velox4j-lib/%s/%s", System.getProperty("os.name"), System.getProperty("os.arch"));
   private static final Pattern LIB_PATTERN = Pattern.compile("^.+$");
   private static final String VELOX4J_LIB_NAME = "libvelox4j.so";
 
@@ -44,7 +42,7 @@ public class JniLibLoader {
       throw new VeloxException("Libraries were already loaded");
     }
     Preconditions.checkArgument(
-        workDir.isDirectory(), "Work directory %s is not a directory", workDir);
+        workDir.isDirectory(), "Work directory %s is not a directory", new Object[] {workDir});
     final List<ResourceFile> libFiles = Resources.getResources(LIB_CONTAINER, LIB_PATTERN);
     if (libFiles.isEmpty()) {
       throw new VeloxException(

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWorkspace.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWorkspace.java
@@ -73,8 +73,9 @@ public class JniWorkspace {
 
   private static void mkdirs(File dir) {
     if (!dir.exists()) {
-      Preconditions.checkState(dir.mkdirs(), "Failed to create directory %s", dir);
+      Preconditions.checkState(dir.mkdirs(), "Failed to create directory %s", new Object[] {dir});
     }
-    Preconditions.checkArgument(dir.isDirectory(), "File %s is not a directory", dir);
+    Preconditions.checkArgument(
+        dir.isDirectory(), "File %s is not a directory", new Object[] {dir});
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWorkspace.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWorkspace.java
@@ -73,9 +73,9 @@ public class JniWorkspace {
 
   private static void mkdirs(File dir) {
     if (!dir.exists()) {
-      Preconditions.checkState(dir.mkdirs(), "Failed to create directory %s", new Object[] {dir});
+      Preconditions.checkState(dir.mkdirs(), String.format("Failed to create directory %s", dir));
     }
     Preconditions.checkArgument(
-        dir.isDirectory(), "File %s is not a directory", new Object[] {dir});
+        dir.isDirectory(), String.format("File %s is not a directory", dir));
   }
 }

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/HashJoinNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/HashJoinNode.java
@@ -57,8 +57,7 @@ public class HashJoinNode extends AbstractJoinNode {
       @JsonProperty("nullAware") boolean nullAware) {
     Preconditions.checkArgument(
         sources.size() == 2,
-        "HashJoinNode should have 2 sources, but has %s",
-        new Object[] {sources.size()});
+        String.format("HashJoinNode should have 2 sources, but has %s", sources.size()));
     return new HashJoinNode(
         id,
         joinType,

--- a/src/main/java/io/github/zhztheplayer/velox4j/plan/HashJoinNode.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/plan/HashJoinNode.java
@@ -56,7 +56,9 @@ public class HashJoinNode extends AbstractJoinNode {
       @JsonProperty("outputType") RowType outputType,
       @JsonProperty("nullAware") boolean nullAware) {
     Preconditions.checkArgument(
-        sources.size() == 2, "HashJoinNode should have 2 sources, but has %s", sources.size());
+        sources.size() == 2,
+        "HashJoinNode should have 2 sources, but has %s",
+        new Object[] {sources.size()});
     return new HashJoinNode(
         id,
         joinType,

--- a/src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java
@@ -83,7 +83,8 @@ public class Resources {
         final File fileContainer = new File(containerUrl.getPath());
         Preconditions.checkState(
             fileContainer.exists() && fileContainer.isDirectory(),
-            "Specified file container " + containerUrl + " is not a directory or not a file");
+            "Specified file container %s is not a directory or not a file",
+            new Object[] {containerUrl});
         getResourcesFromDirectory(container, fileContainer, fileContainer, pattern, buffer);
         break;
       case "jar":
@@ -97,7 +98,8 @@ public class Resources {
         final File jarFile = new File(jarPath);
         Preconditions.checkState(
             jarFile.exists() && jarFile.isFile(),
-            "Specified Jar container " + containerUrl + " is not a Jar file");
+            "Specified Jar container %s is not a Jar file",
+            new Object[] {containerUrl});
         final String dir = m.group(2);
         getResourcesFromJarFile(container, jarFile, dir, pattern, buffer);
         break;
@@ -162,7 +164,8 @@ public class Resources {
   }
 
   public static void copyResource(String fromPath, File toFile) {
-    Preconditions.checkArgument(!toFile.isDirectory(), "File %s is not a file", toFile);
+    Preconditions.checkArgument(
+        !toFile.isDirectory(), "File %s is not a file", new Object[] {toFile});
     final ClassLoader classloader = Thread.currentThread().getContextClassLoader();
     try (final InputStream is =
         new BufferedInputStream(

--- a/src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/resource/Resources.java
@@ -83,8 +83,8 @@ public class Resources {
         final File fileContainer = new File(containerUrl.getPath());
         Preconditions.checkState(
             fileContainer.exists() && fileContainer.isDirectory(),
-            "Specified file container %s is not a directory or not a file",
-            new Object[] {containerUrl});
+            String.format(
+                "Specified file container %s is not a directory or not a file", containerUrl));
         getResourcesFromDirectory(container, fileContainer, fileContainer, pattern, buffer);
         break;
       case "jar":
@@ -98,8 +98,7 @@ public class Resources {
         final File jarFile = new File(jarPath);
         Preconditions.checkState(
             jarFile.exists() && jarFile.isFile(),
-            "Specified Jar container %s is not a Jar file",
-            new Object[] {containerUrl});
+            String.format("Specified Jar container %s is not a Jar file", containerUrl));
         final String dir = m.group(2);
         getResourcesFromJarFile(container, jarFile, dir, pattern, buffer);
         break;
@@ -165,7 +164,7 @@ public class Resources {
 
   public static void copyResource(String fromPath, File toFile) {
     Preconditions.checkArgument(
-        !toFile.isDirectory(), "File %s is not a file", new Object[] {toFile});
+        !toFile.isDirectory(), String.format("File %s is not a file", toFile));
     final ClassLoader classloader = Thread.currentThread().getContextClassLoader();
     try (final InputStream is =
         new BufferedInputStream(

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
@@ -69,8 +69,7 @@ public class PolymorphicDeserializer {
       final String value = objectNode.get(key).asText();
       Preconditions.checkArgument(
           registry.contains(value),
-          "Value %s not registered in registry: %s",
-          new Object[] {value, registry.prefixAndKey()});
+          String.format("Value %s not registered in registry: %s", value, registry.prefixAndKey()));
       if (registry.isFactory(value)) {
         final SerdeRegistryFactory rf = registry.getFactory(value);
         final SerdeRegistry nextRegistry = findRegistry(rf, objectNode);
@@ -142,7 +141,7 @@ public class PolymorphicDeserializer {
               "Class %s is an interface which is not currently supported by PolymorphicDeserializer",
               clazz));
       Preconditions.checkArgument(
-          !baseClasses.contains(clazz), "Base class already registered: %s", new Object[] {clazz});
+          !baseClasses.contains(clazz), String.format("Base class already registered: %s", clazz));
       baseClasses.add(clazz);
     }
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicDeserializer.java
@@ -70,8 +70,7 @@ public class PolymorphicDeserializer {
       Preconditions.checkArgument(
           registry.contains(value),
           "Value %s not registered in registry: %s",
-          value,
-          registry.prefixAndKey());
+          new Object[] {value, registry.prefixAndKey()});
       if (registry.isFactory(value)) {
         final SerdeRegistryFactory rf = registry.getFactory(value);
         final SerdeRegistry nextRegistry = findRegistry(rf, objectNode);
@@ -143,7 +142,7 @@ public class PolymorphicDeserializer {
               "Class %s is an interface which is not currently supported by PolymorphicDeserializer",
               clazz));
       Preconditions.checkArgument(
-          !baseClasses.contains(clazz), "Base class already registered: %s", clazz);
+          !baseClasses.contains(clazz), "Base class already registered: %s", new Object[] {clazz});
       baseClasses.add(clazz);
     }
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicSerializer.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicSerializer.java
@@ -93,7 +93,7 @@ public final class PolymorphicSerializer {
               "Class %s is an interface which is not currently supported by PolymorphicSerializer",
               clazz));
       Preconditions.checkArgument(
-          !baseClasses.contains(clazz), "Base class already registered: %s", clazz);
+          !baseClasses.contains(clazz), "Base class already registered: %s", new Object[] {clazz});
       baseClasses.add(clazz);
     }
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicSerializer.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/serde/PolymorphicSerializer.java
@@ -93,7 +93,7 @@ public final class PolymorphicSerializer {
               "Class %s is an interface which is not currently supported by PolymorphicSerializer",
               clazz));
       Preconditions.checkArgument(
-          !baseClasses.contains(clazz), "Base class already registered: %s", new Object[] {clazz});
+          !baseClasses.contains(clazz), String.format("Base class already registered: %s", clazz));
       baseClasses.add(clazz);
     }
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/type/ArrayType.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/type/ArrayType.java
@@ -31,8 +31,7 @@ public class ArrayType extends Type {
   private ArrayType(@JsonProperty("cTypes") List<Type> children) {
     Preconditions.checkArgument(
         children.size() == 1,
-        "ArrayType should have 1 child, but has %s",
-        new Object[] {children.size()});
+        String.format("ArrayType should have 1 child, but has %s", children.size()));
     this.children = children;
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/type/ArrayType.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/type/ArrayType.java
@@ -30,7 +30,9 @@ public class ArrayType extends Type {
   @JsonCreator
   private ArrayType(@JsonProperty("cTypes") List<Type> children) {
     Preconditions.checkArgument(
-        children.size() == 1, "ArrayType should have 1 child, but has %s", children.size());
+        children.size() == 1,
+        "ArrayType should have 1 child, but has %s",
+        new Object[] {children.size()});
     this.children = children;
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/type/MapType.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/type/MapType.java
@@ -30,7 +30,9 @@ public class MapType extends Type {
   @JsonCreator
   private MapType(@JsonProperty("cTypes") List<Type> children) {
     Preconditions.checkArgument(
-        children.size() == 2, "MapType should have 2 children, but has %s", children.size());
+        children.size() == 2,
+        "MapType should have 2 children, but has %s",
+        new Object[] {children.size()});
     this.children = children;
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/type/MapType.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/type/MapType.java
@@ -31,8 +31,7 @@ public class MapType extends Type {
   private MapType(@JsonProperty("cTypes") List<Type> children) {
     Preconditions.checkArgument(
         children.size() == 2,
-        "MapType should have 2 children, but has %s",
-        new Object[] {children.size()});
+        String.format("MapType should have 2 children, but has %s", children.size()));
     this.children = children;
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/serde/VariantSerdeTest.java
@@ -26,20 +26,7 @@ import org.junit.Test;
 
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 import io.github.zhztheplayer.velox4j.test.Velox4jTests;
-import io.github.zhztheplayer.velox4j.variant.ArrayValue;
-import io.github.zhztheplayer.velox4j.variant.BigIntValue;
-import io.github.zhztheplayer.velox4j.variant.BooleanValue;
-import io.github.zhztheplayer.velox4j.variant.DoubleValue;
-import io.github.zhztheplayer.velox4j.variant.HugeIntValue;
-import io.github.zhztheplayer.velox4j.variant.IntegerValue;
-import io.github.zhztheplayer.velox4j.variant.MapValue;
-import io.github.zhztheplayer.velox4j.variant.RealValue;
-import io.github.zhztheplayer.velox4j.variant.RowValue;
-import io.github.zhztheplayer.velox4j.variant.SmallIntValue;
-import io.github.zhztheplayer.velox4j.variant.TimestampValue;
-import io.github.zhztheplayer.velox4j.variant.TinyIntValue;
-import io.github.zhztheplayer.velox4j.variant.VarBinaryValue;
-import io.github.zhztheplayer.velox4j.variant.VarCharValue;
+import io.github.zhztheplayer.velox4j.variant.*;
 
 public class VariantSerdeTest {
   @BeforeClass
@@ -147,13 +134,14 @@ public class VariantSerdeTest {
   public void testMapValue() {
     SerdeTests.testVariantRoundTrip(
         new MapValue(
-            ImmutableMap.of(
-                new IntegerValue(100), new BooleanValue(false),
-                new IntegerValue(1000), new BooleanValue(true),
-                new IntegerValue(400), new BooleanValue(false),
-                new IntegerValue(800), new BooleanValue(false),
-                new IntegerValue(200), new BooleanValue(true),
-                new IntegerValue(500), new BooleanValue(true))));
+            ImmutableMap.<Variant, Variant>builder()
+                .put(new IntegerValue(100), new BooleanValue(false))
+                .put(new IntegerValue(1000), new BooleanValue(true))
+                .put(new IntegerValue(400), new BooleanValue(false))
+                .put(new IntegerValue(800), new BooleanValue(false))
+                .put(new IntegerValue(200), new BooleanValue(true))
+                .put(new IntegerValue(500), new BooleanValue(true))
+                .build()));
     SerdeTests.testVariantRoundTrip(new MapValue(null));
   }
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/ResourceTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/ResourceTests.java
@@ -31,7 +31,7 @@ public final class ResourceTests {
   public static String readResourceAsString(String path) {
     final ClassLoader classloader = Thread.currentThread().getContextClassLoader();
     try (final InputStream is = classloader.getResourceAsStream(path)) {
-      Preconditions.checkArgument(is != null, "Resource %s not found", path);
+      Preconditions.checkArgument(is != null, "Resource %s not found", new Object[] {path});
       final ByteArrayOutputStream o = new ByteArrayOutputStream();
       while (true) {
         int b = is.read();

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/ResourceTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/ResourceTests.java
@@ -31,7 +31,7 @@ public final class ResourceTests {
   public static String readResourceAsString(String path) {
     final ClassLoader classloader = Thread.currentThread().getContextClassLoader();
     try (final InputStream is = classloader.getResourceAsStream(path)) {
-      Preconditions.checkArgument(is != null, "Resource %s not found", new Object[] {path});
+      Preconditions.checkArgument(is != null, String.format("Resource %s not found", path));
       final ByteArrayOutputStream o = new ByteArrayOutputStream();
       while (true) {
         int b = is.read();

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/dataset/tpch/DownloadedTpchDataset.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/dataset/tpch/DownloadedTpchDataset.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
 
@@ -135,7 +135,7 @@ class DownloadedTpchDataset implements TpchDataset {
   private void extractTarGz(Path archive, Path destDir) throws IOException {
     try (GZIPInputStream gis = new GZIPInputStream(Files.newInputStream(archive));
         TarArchiveInputStream tis = new TarArchiveInputStream(gis)) {
-      TarArchiveEntry entry;
+      ArchiveEntry entry;
       while ((entry = tis.getNextEntry()) != null) {
         final Path outPath = destDir.resolve(entry.getName());
         if (entry.isDirectory()) {


### PR DESCRIPTION
This is because user may use a lower version of Guava that doesn't have the new Guava APIs (E.g., the new overloaded Precondition APIs that were added in Guava 20). We do the change as we hope the code is compatible with lower Guava versions.