### PR TITLE
WIP: Add API for Arrow schema / Velox row-type interoperability

### DIFF
--- a/src/main/cpp/main/velox4j/arrow/Arrow.cc
+++ b/src/main/cpp/main/velox4j/arrow/Arrow.cc
@@ -45,10 +45,25 @@ void flatten(VectorPtr& in) {
 
 ArrowOptions makeOptions() {
   ArrowOptions options;
+  // TODO: Make the timestamp unit configurable or included in presets.
   options.timestampUnit = static_cast<TimestampUnit>(6);
   return options;
 }
 } // namespace
+
+void fromTypeToArrow(
+    memory::MemoryPool* pool,
+    TypePtr type,
+    ArrowSchema* cSchema) {
+  auto options = makeOptions();
+  auto emptyVector = BaseVector::create(type, 0, pool);
+  exportToArrow(emptyVector, *cSchema, options);
+}
+
+TypePtr fromArrowToType(ArrowSchema* cSchema) {
+  auto options = makeOptions();
+  return importFromArrow(*cSchema);
+}
 
 void fromBaseVectorToArrow(
     VectorPtr vector,

--- a/src/main/cpp/main/velox4j/arrow/Arrow.h
+++ b/src/main/cpp/main/velox4j/arrow/Arrow.h
@@ -23,6 +23,16 @@ struct ArrowArray;
 struct ArrowSchema;
 
 namespace velox4j {
+
+// Exports the input Velox type to Arrow C schema.
+void fromTypeToArrow(
+    facebook::velox::memory::MemoryPool* pool,
+    facebook::velox::TypePtr type,
+    ArrowSchema* cSchema);
+
+// Imports the given Arrow C schema into a Velox type, then returns it.
+facebook::velox::TypePtr fromArrowToType(ArrowSchema* cSchema);
+
 // Exports the input base vector to Arrow ABI structs.
 void fromBaseVectorToArrow(
     facebook::velox::VectorPtr vector,

--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -155,6 +155,15 @@ jstring variantInferType(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_END(nullptr);
 }
 
+jstring arrowToType(JNIEnv* env, jobject javaThis, jlong cSchema) {
+  JNI_METHOD_START
+  auto type = fromArrowToType(reinterpret_cast<struct ArrowSchema*>(cSchema));
+  auto serializedDynamic = type->serialize();
+  auto typeJson = folly::toPrettyJson(serializedDynamic);
+  return env->NewStringUTF(typeJson.data());
+  JNI_METHOD_END(nullptr)
+}
+
 void baseVectorToArrow(
     JNIEnv* env,
     jobject javaThis,
@@ -344,6 +353,8 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       kTypeString,
       kTypeString,
       nullptr);
+  addNativeMethod(
+      "arrowToType", (void*)arrowToType, kTypeString, kTypeLong, nullptr);
   addNativeMethod(
       "baseVectorToArrow",
       (void*)baseVectorToArrow,

--- a/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
@@ -23,17 +23,53 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.table.Table;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 
 import io.github.zhztheplayer.velox4j.data.BaseVector;
 import io.github.zhztheplayer.velox4j.data.RowVector;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
 import io.github.zhztheplayer.velox4j.jni.StaticJniApi;
+import io.github.zhztheplayer.velox4j.type.RowType;
+import io.github.zhztheplayer.velox4j.type.Type;
 
 public class Arrow {
   private final JniApi jniApi;
 
   public Arrow(JniApi jniApi) {
     this.jniApi = jniApi;
+  }
+
+  public Schema toArrowSchema(BufferAllocator alloc, RowType type) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc)) {
+      jniApi.typeToArrow(type, cSchema);
+      final Schema schema = Data.importSchema(alloc, cSchema, null);
+      return schema;
+    }
+  }
+
+  public static RowType fromArrowSchema(BufferAllocator alloc, Schema schema) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc)) {
+      Data.exportSchema(alloc, schema, null, cSchema);
+      final RowType type = (RowType) StaticJniApi.get().arrowToRowType(cSchema);
+      return type;
+    }
+  }
+
+  public Field toArrowField(BufferAllocator alloc, Type type) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc)) {
+      jniApi.typeToArrow(type, cSchema);
+      final Field field = Data.importField(alloc, cSchema, null);
+      return field;
+    }
+  }
+
+  public static Type fromArrowField(BufferAllocator alloc, Field field) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc)) {
+      Data.exportField(alloc, field, null, cSchema);
+      final Type type = StaticJniApi.get().arrowToRowType(cSchema);
+      return type;
+    }
   }
 
   public static FieldVector toArrowVector(BufferAllocator alloc, BaseVector vector) {
@@ -45,21 +81,21 @@ public class Arrow {
     }
   }
 
-  public static Table toArrowTable(BufferAllocator alloc, RowVector vector) {
-    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
-        final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
-      StaticJniApi.get().baseVectorToArrow(vector, cSchema, cArray);
-      final VectorSchemaRoot vsr = Data.importVectorSchemaRoot(alloc, cArray, cSchema, null);
-      return new Table(vsr);
-    }
-  }
-
   public BaseVector fromArrowVector(BufferAllocator alloc, FieldVector arrowVector) {
     try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
         final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
       Data.exportVector(alloc, arrowVector, null, cArray, cSchema);
       final BaseVector imported = jniApi.arrowToBaseVector(cSchema, cArray);
       return imported;
+    }
+  }
+
+  public static Table toArrowTable(BufferAllocator alloc, RowVector vector) {
+    try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
+        final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
+      StaticJniApi.get().baseVectorToArrow(vector, cSchema, cArray);
+      final VectorSchemaRoot vsr = Data.importVectorSchemaRoot(alloc, cArray, cSchema, null);
+      return new Table(vsr);
     }
   }
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniApi.java
@@ -91,6 +91,11 @@ public final class JniApi {
     return new ExternalStreams.BlockingQueue(jni.createBlockingQueue());
   }
 
+  public void typeToArrow(Type type, ArrowSchema schema) {
+    final String typeJson = Serde.toJson(type);
+    jni.typeToArrow(typeJson, schema.memoryAddress());
+  }
+
   public BaseVector createEmptyBaseVector(Type type) {
     final String typeJson = Serde.toJson(type);
     return baseVectorWrap(jni.createEmptyBaseVector(typeJson));

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWrapper.java
@@ -57,6 +57,9 @@ final class JniWrapper {
 
   native long createBlockingQueue();
 
+  // For Type.
+  native void typeToArrow(String typeJson, long cSchema);
+
   // For BaseVector / RowVector / SelectivityVector.
   native long createEmptyBaseVector(String typeJson);
 

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniApi.java
@@ -106,6 +106,11 @@ public class StaticJniApi {
     return Serde.fromJson(typeJson, Type.class);
   }
 
+  public Type arrowToRowType(ArrowSchema schema) {
+    final String typeJson = jni.arrowToType(schema.memoryAddress());
+    return Serde.fromJson(typeJson, Type.class);
+  }
+
   public void baseVectorToArrow(BaseVector vector, ArrowSchema schema, ArrowArray array) {
     jni.baseVectorToArrow(vector.id(), schema.memoryAddress(), array.memoryAddress());
   }

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/StaticJniWrapper.java
@@ -63,6 +63,9 @@ public class StaticJniWrapper {
   // For Variant.
   native String variantInferType(String json);
 
+  // For Type.
+  native String arrowToType(long cSchema);
+
   // For BaseVector / RowVector / SelectivityVector.
   native void baseVectorToArrow(long rvid, long cSchema, long cArray);
 

--- a/src/test/java/io/github/zhztheplayer/velox4j/test/TypeTests.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/test/TypeTests.java
@@ -1,0 +1,28 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.github.zhztheplayer.velox4j.test;
+
+import org.junit.Assert;
+
+import io.github.zhztheplayer.velox4j.serde.Serde;
+import io.github.zhztheplayer.velox4j.type.Type;
+
+public class TypeTests {
+  public static void assertEquals(Type expected, Type actual) {
+    Assert.assertEquals(Serde.toPrettyJson(expected), Serde.toPrettyJson(actual));
+  }
+}


### PR DESCRIPTION
As title. Add new APIs for converting between Velox types and Arrow types.