### PR TITLE
Add some default HiveConfig options for Spark preset

### DIFF
--- a/src/main/cpp/main/velox4j/init/Init.cc
+++ b/src/main/cpp/main/velox4j/init/Init.cc
@@ -88,8 +88,19 @@ void initForSpark() {
   connector::hive::HiveInsertFileNameGenerator::registerSerDe();
   connector::registerConnector(std::make_shared<connector::hive::HiveConnector>(
       "connector-hive",
-      std::make_shared<facebook::velox::config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()),
+      std::make_shared<
+          config::ConfigBase>(std::unordered_map<std::string, std::string>{
+          {connector::hive::HiveConfig::kReadTimestampPartitionValueAsLocalTime,
+           "false"},
+          {connector::hive::HiveConfig::kParquetUseColumnNames, "true"},
+          {connector::hive::HiveConfig::kOrcUseColumnNames, "true"},
+          {connector::hive::HiveConfig::kEnableFileHandleCache, "false"},
+          {connector::hive::HiveConfig::kMaxCoalescedBytes, "67108864"},
+          {connector::hive::HiveConfig::kMaxCoalescedDistance, "512KB"},
+          {connector::hive::HiveConfig::kPrefetchRowGroups, "1"},
+          {connector::hive::HiveConfig::kLoadQuantum, "268435456"},
+          {connector::hive::HiveConfig::kFooterEstimatedSize, "32768"},
+          {connector::hive::HiveConfig::kFilePreloadThreshold, "1048576"}}),
       nullptr));
   ExternalStreamConnectorSplit::registerSerDe();
   ExternalStreamTableHandle::registerSerDe();


### PR DESCRIPTION
The configurations are synchronized from Gluten. Among them, 

```
{connector::hive::HiveConfig::kParquetUseColumnNames, "true"},
{connector::hive::HiveConfig::kOrcUseColumnNames, "true"}
```

are important to allow the file reader matches file schema correctly using the requested read schema given by Spark. Otherwise, the following error or similar might occur:

```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Converted type INTEGER is not allowed for requested type ARRAY<VARCHAR>
Retriable: False
Expression: !requestedType || requestedType->kind() == TypeKind::INTEGER || requestedType->kind() == TypeKind::BIGINT
Context: Split [Hive: file:/tmp/spark-42219011-7b47-4195-afd9-5d2e7c2ef314/part-00000-c705d479-ee8a-4282-9252-f237ed5931c5-c000.snappy.parquet 0 - 909] Task Task - EID 0
Additional Context: Operator: TableScan[plan-id-1] 0
Function: convertType
File: /opt/code/velox4j/src/main/cpp/build/_deps/velox-src/velox/dwio/parquet/reader/ParquetReader.cpp
Line: 906
Stack trace:
# 0  std::shared_ptr<facebook::velox::VeloxException::State const> facebook::velox::VeloxException::State::make<facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1}>(facebook::velox::VeloxException::Type, facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1})
# 1  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 2  facebook::velox::VeloxRuntimeError::VeloxRuntimeError(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, std::basic_string_view<char, std::char_traits<char> >)
# 3  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 4  facebook::velox::parquet::ReaderBase::convertType(facebook::velox::parquet::thrift::SchemaElement const&, std::shared_ptr<facebook::velox::Type const> const&) const
# 5  facebook::velox::parquet::ReaderBase::getParquetColumnInfo(unsigned int, unsigned int, unsigned int, unsigned int, unsigned int&, unsigned int&, std::shared_ptr<facebook::velox::Type const> const&, std::shared_ptr<facebook::velox::Type const> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) const
# 6  facebook::velox::parquet::ReaderBase::getParquetColumnInfo(unsigned int, unsigned int, unsigned int, unsigned int, unsigned int&, unsigned int&, std::shared_ptr<facebook::velox::Type const> const&, std::shared_ptr<facebook::velox::Type const> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) const
# 7  facebook::velox::parquet::ReaderBase::getParquetColumnInfo(unsigned int, unsigned int, unsigned int, unsigned int, unsigned int&, unsigned int&, std::shared_ptr<facebook::velox::Type const> const&, std::shared_ptr<facebook::velox::Type const> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) const
# 8  facebook::velox::parquet::ReaderBase::initializeSchema()
# 9  facebook::velox::parquet::ReaderBase::ReaderBase(std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&)
# 10 decltype (::new ((void*)(0)) facebook::velox::parquet::ReaderBase((declval<std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> > >)(), (declval<facebook::velox::dwio::common::ReaderOptions const&>)())) std::construct_at<facebook::velox::parquet::ReaderBase, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(facebook::velox::parquet::ReaderBase*, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 11 void std::allocator_traits<std::allocator<facebook::velox::parquet::ReaderBase> >::construct<facebook::velox::parquet::ReaderBase, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::allocator<facebook::velox::parquet::ReaderBase>&, facebook::velox::parquet::ReaderBase*, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 12 std::_Sp_counted_ptr_inplace<facebook::velox::parquet::ReaderBase, std::allocator<facebook::velox::parquet::ReaderBase>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::allocator<facebook::velox::parquet::ReaderBase>, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 13 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<facebook::velox::parquet::ReaderBase, std::allocator<facebook::velox::parquet::ReaderBase>, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(facebook::velox::parquet::ReaderBase*&, std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::parquet::ReaderBase> >, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 14 std::__shared_ptr<facebook::velox::parquet::ReaderBase, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<facebook::velox::parquet::ReaderBase>, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::parquet::ReaderBase> >, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 15 std::shared_ptr<facebook::velox::parquet::ReaderBase>::shared_ptr<std::allocator<facebook::velox::parquet::ReaderBase>, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::parquet::ReaderBase> >, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 16 std::shared_ptr<facebook::velox::parquet::ReaderBase> std::allocate_shared<facebook::velox::parquet::ReaderBase, std::allocator<facebook::velox::parquet::ReaderBase>, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::allocator<facebook::velox::parquet::ReaderBase> const&, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 17 std::shared_ptr<facebook::velox::parquet::ReaderBase> std::make_shared<facebook::velox::parquet::ReaderBase, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 18 facebook::velox::parquet::ParquetReader::ParquetReader(std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&)
# 19 std::_MakeUniq<facebook::velox::parquet::ParquetReader>::__single_object std::make_unique<facebook::velox::parquet::ParquetReader, std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&>(std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >&&, facebook::velox::dwio::common::ReaderOptions const&)
# 20 facebook::velox::parquet::ParquetReaderFactory::createReader(std::unique_ptr<facebook::velox::dwio::common::BufferedInput, std::default_delete<facebook::velox::dwio::common::BufferedInput> >, facebook::velox::dwio::common::ReaderOptions const&)
# 21 facebook::velox::connector::hive::SplitReader::createReader()
# 22 facebook::velox::connector::hive::SplitReader::prepareSplit(std::shared_ptr<facebook::velox::common::MetadataFilter>, facebook::velox::dwio::common::RuntimeStatistics&)
# 23 facebook::velox::connector::hive::HiveDataSource::addSplit(std::shared_ptr<facebook::velox::connector::ConnectorSplit>)
# 24 facebook::velox::exec::TableScan::getSplit()
# 25 facebook::velox::exec::TableScan::getOutput()
# 26 facebook::velox::exec::(anonymous namespace)::getOutput(facebook::velox::exec::Operator*, std::shared_ptr<facebook::velox::RowVector>&)
# 27 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::{lambda()#10}::operator()() const
# 28 void facebook::velox::exec::Driver::withDeltaCpuWallTimer<facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::{lambda()#10}>(facebook::velox::exec::Operator*, facebook::velox::CpuWallTiming facebook::velox::exec::OperatorStats::*, facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::{lambda()#10}&&)
# 29 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 30 facebook::velox::exec::Driver::next(folly::SemiFuture<folly::Unit>*, facebook::velox::exec::Operator*&, facebook::velox::exec::BlockingReason&)
# 31 facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
# 32 velox4j::SerialTask::advance0(bool)
# 33 velox4j::SerialTask::advance()
# 34 velox4j::(anonymous namespace)::upIteratorAdvance(JNIEnv_*, _jobject*, long)
# 35 0x0000f33d548689ab
# 36 0x0000f33d548689aa
```