### PR TITLE
Fix assertion error with empty scan

### DIFF
--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -172,7 +172,6 @@ void SerialTask::saveDrivers() {
     task_->testingVisitDrivers([&](exec::Driver* driver) -> void {
       drivers_.push_back(driver->shared_from_this());
     });
-    VELOX_CHECK(!drivers_.empty());
   }
 }
 


### PR DESCRIPTION
Fix the known error caused by empty scan. Add a test to guard.