### PR TITLE
Remove usage of new Arrow APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <surefire.add-opens.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</surefire.add-opens.argLine>
     <java.version>8</java.version>
     <junit.version>4.13.1</junit.version>
-    <arrow.version>17.0.0</arrow.version>
+    <arrow.version>18.1.0</arrow.version>
     <guava.version>33.4.0-jre</guava.version>
     <jackson.version>2.18.0</jackson.version>
     <commons-io.version>2.18.0</commons-io.version>

--- a/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/arrow/Arrow.java
@@ -22,7 +22,6 @@ import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.table.Table;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -90,19 +89,18 @@ public class Arrow {
     }
   }
 
-  public static Table toArrowTable(BufferAllocator alloc, RowVector vector) {
+  public static VectorSchemaRoot toArrowVectorSchemaRoot(BufferAllocator alloc, RowVector vector) {
     try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
         final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
       StaticJniApi.get().baseVectorToArrow(vector, cSchema, cArray);
       final VectorSchemaRoot vsr = Data.importVectorSchemaRoot(alloc, cArray, cSchema, null);
-      return new Table(vsr);
+      return vsr;
     }
   }
 
-  public RowVector fromArrowTable(BufferAllocator alloc, Table table) {
+  public RowVector fromVectorSchemaRoot(BufferAllocator alloc, VectorSchemaRoot vsr) {
     try (final ArrowSchema cSchema = ArrowSchema.allocateNew(alloc);
-        final ArrowArray cArray = ArrowArray.allocateNew(alloc);
-        final VectorSchemaRoot vsr = table.toVectorSchemaRoot()) {
+        final ArrowArray cArray = ArrowArray.allocateNew(alloc)) {
       Data.exportVectorSchemaRoot(alloc, vsr, null, cArray, cSchema);
       final BaseVector imported = jniApi.arrowToBaseVector(cSchema, cArray);
       return imported.asRowVector();

--- a/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/data/RowVector.java
@@ -18,7 +18,6 @@ package io.github.zhztheplayer.velox4j.data;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.table.Table;
 
 import io.github.zhztheplayer.velox4j.arrow.Arrow;
 import io.github.zhztheplayer.velox4j.jni.JniApi;
@@ -30,8 +29,7 @@ public class RowVector extends BaseVector {
 
   @Override
   public String toString(BufferAllocator alloc) {
-    try (final Table t = Arrow.toArrowTable(alloc, this);
-        final VectorSchemaRoot vsr = t.toVectorSchemaRoot()) {
+    try (final VectorSchemaRoot vsr = Arrow.toArrowVectorSchemaRoot(alloc, this)) {
       return vsr.contentToTSVString();
     }
   }

--- a/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
+++ b/src/test/java/io/github/zhztheplayer/velox4j/arrow/ArrowTest.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.table.Table;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.*;
@@ -68,7 +68,7 @@ public class ArrowTest {
   }
 
   @Test
-  public void testBaseVectorRoundTrip() {
+  public void testBaseVectorRoundTrip1() {
     final BaseVector input = BaseVectorTests.newSampleIntVector(session, arrowAlloc);
     final FieldVector arrowVector = Arrow.toArrowVector(arrowAlloc, input);
     final BaseVector imported = session.arrowOps().fromArrowVector(arrowAlloc, arrowVector);
@@ -79,19 +79,10 @@ public class ArrowTest {
   @Test
   public void testRowVectorRoundTrip1() {
     final RowVector input = BaseVectorTests.newSampleRowVector(session);
-    final Table arrowTable = Arrow.toArrowTable(arrowAlloc, input);
-    final RowVector imported = session.arrowOps().fromArrowTable(arrowAlloc, arrowTable);
+    final VectorSchemaRoot vsr = Arrow.toArrowVectorSchemaRoot(arrowAlloc, input);
+    final RowVector imported = session.arrowOps().fromVectorSchemaRoot(arrowAlloc, vsr);
     BaseVectorTests.assertEquals(input, imported);
-    arrowTable.close();
-  }
-
-  @Test
-  public void testRowVectorRoundTrip2() {
-    final RowVector input = BaseVectorTests.newSampleRowVector(session);
-    final Table arrowTable = Arrow.toArrowTable(arrowAlloc, input);
-    final RowVector imported = session.arrowOps().fromArrowTable(arrowAlloc, arrowTable);
-    BaseVectorTests.assertEquals(input, imported);
-    arrowTable.close();
+    vsr.close();
   }
 
   @Test


### PR DESCRIPTION
This patch mainly removes the usage of new Arrow `Table` APIs to make sure the Velox4J binary is compatible with elder Arrow versions.

Velox4J will directly depend on Arrow 18.1, but tested, it can be compatible with as low as 9.0 after this change.