### PR TITLE
Keep arrow-vector as a direct Maven dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ public static void main(String[] args) {
   // 9. Collect and print results.
   while (itr.hasNext()) {
     final RowVector rowVector = itr.next(); // 9.1. Get next RowVector returned by Velox.
-    final VectorSchemaRoot vsr = Arrow.toArrowTable(new RootAllocator(), rowVector).toVectorSchemaRoot(); // 9.2. Convert the RowVector into Arrow format (an Arrow VectorSchemaRoot in this case).
+    final VectorSchemaRoot vsr = Arrow.toArrowVectorSchemaRoot(new RootAllocator(), rowVector); // 9.2. Convert the RowVector into Arrow format (an Arrow VectorSchemaRoot in this case).
     System.out.println(vsr.contentToTSVString()); // 9.3. Print the arrow table to stdout.
     vsr.close(); // 9.4. Release the Arrow VectorSchemaRoot.
   }

--- a/pom.xml
+++ b/pom.xml
@@ -324,10 +324,6 @@
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>io.github.zhztheplayer.velox4j.shaded.org.apache.commons</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.slf4j</pattern>
-                  <shadedPattern>io.github.zhztheplayer.velox4j.shaded.org.slf4j</shadedPattern>
-                </relocation>
               </relocations>
 
               <!-- be conservative; you can turn this on if you want smaller jars -->

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,11 @@
             </goals>
             <phase>package</phase>
             <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>org.apache.arrow:arrow-vector</exclude>
+                </excludes>
+              </artifactSet>
               <!-- replace the main jar; no extra classifier -->
               <shadedArtifactAttached>false</shadedArtifactAttached>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,32 +54,6 @@
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
       <version>${arrow.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.datatype</groupId>
-          <artifactId>jackson-datatype-jsr310</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,16 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-c-data</artifactId>
+      <version>${arrow.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-unsafe</artifactId>
+      <version>${arrow.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
@@ -105,16 +115,6 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
       <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.arrow</groupId>
-      <artifactId>arrow-c-data</artifactId>
-      <version>${arrow.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.arrow</groupId>
-      <artifactId>arrow-memory-unsafe</artifactId>
-      <version>${arrow.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -314,7 +314,7 @@
             <configuration>
               <artifactSet>
                 <excludes>
-                  <exclude>org.apache.arrow:arrow-vector</exclude>
+                  <exclude>org.apache.arrow:*</exclude>
                 </excludes>
               </artifactSet>
               <!-- replace the main jar; no extra classifier -->

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWorkspace.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/JniWorkspace.java
@@ -23,13 +23,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.github.zhztheplayer.velox4j.exception.VeloxException;
 
 public class JniWorkspace {
-  private static final Logger LOG = LoggerFactory.getLogger(JniWorkspace.class);
   private static final Map<String, JniWorkspace> INSTANCES = new ConcurrentHashMap<>();
 
   private static final String DEFAULT_WORK_DIR;
@@ -51,7 +48,7 @@ public class JniWorkspace {
     try {
       this.workDir = workDir;
       mkdirs(this.workDir);
-      LOG.info("JNI workspace created in directory {}", this.workDir);
+      System.out.printf("JNI workspace created in directory %s.%n", this.workDir);
     } catch (Exception e) {
       throw new VeloxException(e);
     }


### PR DESCRIPTION
Follows https://github.com/velox4j/velox4j/pull/367.

Otherwise, arrow will be embedded in the uber Jar. We aim to let user exclude it freely.