### PR TITLE
Enhance compatibility with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
   <properties>
     <skip.cpp.build>false</skip.cpp.build>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <surefire.add-opens.argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</surefire.add-opens.argLine>
+    <surefire.add-opens.argLine>-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.nio=ALL-UNNAMED</surefire.add-opens.argLine>
     <java.version>8</java.version>
     <junit.version>4.13.1</junit.version>
-    <arrow.version>18.1.0</arrow.version>
+    <arrow.version>17.0.0</arrow.version>
     <guava.version>33.4.0-jre</guava.version>
     <jackson.version>2.18.0</jackson.version>
     <commons-io.version>2.18.0</commons-io.version>
@@ -184,7 +184,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.44.4</version>
+        <version>2.30.0</version>
         <configuration>
           <upToDateChecking>
             <enabled>true</enabled>
@@ -195,7 +195,7 @@
               <include>src/test/java/**/*.java</include>
             </includes>
             <googleJavaFormat>
-              <version>1.10.0</version>
+              <version>1.7</version>
               <style>GOOGLE</style>
             </googleJavaFormat>
             <removeUnusedImports></removeUnusedImports>

--- a/src/main/java/io/github/zhztheplayer/velox4j/jni/CppObject.java
+++ b/src/main/java/io/github/zhztheplayer/velox4j/jni/CppObject.java
@@ -32,5 +32,4 @@ public interface CppObject extends AutoCloseable {
   default void close() {
     StaticJniApi.get().releaseCppObject(this);
   }
-  ;
 }


### PR DESCRIPTION
Downgrade the dependencies that is of byte code version higher than 52.0 (JDK8), to make sure the project is buildable with JDK 8.

Previously, only the jar can work with JDK 8 but the source is not able to compile with JDK 8.