### PR TITLE
Save driver references when creating serial task

### DIFF
--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -72,6 +72,8 @@ SerialTask::SerialTask(
     VELOX_FAIL(
         "Task doesn't support single threaded execution: " + task->toString());
   }
+
+  saveDrivers();
 }
 
 SerialTask::~SerialTask() {
@@ -130,7 +132,6 @@ UpIterator::State SerialTask::advance0(bool wait) {
   while (true) {
     auto future = ContinueFuture::makeEmpty();
     auto out = task_->next(&future);
-    saveDrivers();
     if (!future.valid()) {
       // Velox task is not blocked and a row vector should be gotten.
       if (out == nullptr) {
@@ -164,7 +165,7 @@ void SerialTask::saveDrivers() {
     // destroyed together with the drivers themselves in the last call to
     // Task::next (see
     // https://github.com/facebookincubator/velox/blob/4adec182144e23d7c7d6422e0090d5b59eb32b86/velox/exec/Driver.cpp#L727C13-L727C18),
-    // so if a lazy vector is not loaded while the scan is drained, a meaning
+    // so if a lazy vector is not loaded while the scan is drained, a meaningful
     // error
     // (https://github.com/facebookincubator/velox/blob/7af0fce2c27424fbdec1974d96bb1a6d1296419d/velox/dwio/common/ColumnLoader.cpp#L32-L35)
     // can be thrown when the vector is being loaded rather than just crashing


### PR DESCRIPTION
An optimization depending on https://github.com/facebookincubator/velox/pull/14988.

The drivers got right after `Task::create` are more precise than those got from the first `next` call because by the drivers might already be closed before the first `next` call if no there are no outputs from the query execution, e.g., if there is a filter that filters all the scan output out. 