### PR TITLE
Add CI step to ensure compatibility with low Arrow-Java versions

### DIFF
--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Start Docker container
         run: |
           docker run --init -d --name test-container -v ${{ github.workspace }}:/velox4j -w /velox4j ubuntu:24.04 sleep infinity
-      - name: Run setup script / Build
+      - name: Run setup script / Build C++ libraries
         run: |
           docker exec test-container bash -c "
             export CCACHE_DIR=/velox4j/.ccache


### PR DESCRIPTION
Make sure velox4j can build and run with arrow-java 7.0.0. The current default version is 17.0.0. By having this daily check, all the arrow-java versions in between should be guaranteed safe to use together with velox4j.