### PR TITLE
Add `LocalPartitionNode` and `PartitionFunctionSpec` support

### DIFF
--- a/src/main/java/org/boostscale/velox4j/plan/LocalPartitionNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/LocalPartitionNode.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.plan;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import org.boostscale.velox4j.plan.partition.PartitionFunctionSpec;
+
+/**
+ * In-process repartitioning plan node. Partitions data using the specified partition function. Can
+ * be used to gather data from multiple sources (N-to-1) or repartition across pipelines (N-to-M).
+ *
+ * <p>This is Velox's built-in local exchange operator. Unlike {@code ExchangeNode} /{@code
+ * PartitionedOutputNode} (which require parallel execution mode for cross-task data transfer),
+ * {@code LocalPartitionNode} operates within a single Velox task and is compatible with serial
+ * execution mode.
+ */
+public class LocalPartitionNode extends PlanNode {
+
+  /** The type of local partition. */
+  public enum Type {
+    /** N-to-1 exchange: gathers data from multiple sources to a single consumer. */
+    GATHER("GATHER"),
+    /** N-to-M shuffle: repartitions data across multiple consumers. */
+    REPARTITION("REPARTITION");
+
+    private final String value;
+
+    Type(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String toValue() {
+      return value;
+    }
+  }
+
+  private final Type type;
+  private final boolean scaleWriter;
+  private final PartitionFunctionSpec partitionFunctionSpec;
+  private final List<PlanNode> sources;
+
+  @JsonCreator
+  public LocalPartitionNode(
+      @JsonProperty("id") String id,
+      @JsonProperty("type") Type type,
+      @JsonProperty("scaleWriter") boolean scaleWriter,
+      @JsonProperty("partitionFunctionSpec") PartitionFunctionSpec partitionFunctionSpec,
+      @JsonProperty("sources") List<PlanNode> sources) {
+    super(id);
+    this.type = type;
+    this.scaleWriter = scaleWriter;
+    this.partitionFunctionSpec = partitionFunctionSpec;
+    this.sources = sources;
+  }
+
+  @Override
+  protected List<PlanNode> getSources() {
+    return sources;
+  }
+
+  @JsonGetter("type")
+  public Type getType() {
+    return type;
+  }
+
+  @JsonGetter("scaleWriter")
+  public boolean isScaleWriter() {
+    return scaleWriter;
+  }
+
+  @JsonGetter("partitionFunctionSpec")
+  public PartitionFunctionSpec getPartitionFunctionSpec() {
+    return partitionFunctionSpec;
+  }
+}

--- a/src/main/java/org/boostscale/velox4j/plan/partition/GatherPartitionFunctionSpec.java
+++ b/src/main/java/org/boostscale/velox4j/plan/partition/GatherPartitionFunctionSpec.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.plan.partition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/** N-to-1 partition function that gathers all data to a single partition. */
+public class GatherPartitionFunctionSpec extends PartitionFunctionSpec {
+
+  @JsonCreator
+  public GatherPartitionFunctionSpec() {}
+}

--- a/src/main/java/org/boostscale/velox4j/plan/partition/HashPartitionFunctionSpec.java
+++ b/src/main/java/org/boostscale/velox4j/plan/partition/HashPartitionFunctionSpec.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.plan.partition;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.boostscale.velox4j.expression.ConstantTypedExpr;
+import org.boostscale.velox4j.type.RowType;
+
+/**
+ * Hash partition function that distributes data based on hash values of specified key columns. The
+ * same key always maps to the same partition — suitable for distributed shuffle joins.
+ */
+public class HashPartitionFunctionSpec extends PartitionFunctionSpec {
+  private final RowType inputType;
+  private final List<Integer> keyChannels;
+  private final List<ConstantTypedExpr> constants;
+
+  @JsonCreator
+  public HashPartitionFunctionSpec(
+      @JsonProperty("inputType") RowType inputType,
+      @JsonProperty("keyChannels") List<Integer> keyChannels,
+      @JsonProperty("constants") List<ConstantTypedExpr> constants) {
+    this.inputType = inputType;
+    this.keyChannels = keyChannels;
+    this.constants = constants != null ? constants : Collections.emptyList();
+  }
+
+  public HashPartitionFunctionSpec(RowType inputType, List<Integer> keyChannels) {
+    this(inputType, keyChannels, Collections.emptyList());
+  }
+
+  @JsonGetter("inputType")
+  public RowType getInputType() {
+    return inputType;
+  }
+
+  @JsonGetter("keyChannels")
+  public List<Integer> getKeyChannels() {
+    return keyChannels;
+  }
+
+  @JsonGetter("constants")
+  public List<ConstantTypedExpr> getConstants() {
+    return constants;
+  }
+}

--- a/src/main/java/org/boostscale/velox4j/plan/partition/PartitionFunctionSpec.java
+++ b/src/main/java/org/boostscale/velox4j/plan/partition/PartitionFunctionSpec.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan.partition;
 
+import org.boostscale.velox4j.plan.LocalPartitionNode;
 import org.boostscale.velox4j.serializable.ISerializable;
 
 /** Base class for partition function specifications used by {@link LocalPartitionNode}. */

--- a/src/main/java/org/boostscale/velox4j/plan/partition/PartitionFunctionSpec.java
+++ b/src/main/java/org/boostscale/velox4j/plan/partition/PartitionFunctionSpec.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.plan.partition;
+
+import org.boostscale.velox4j.serializable.ISerializable;
+
+/** Base class for partition function specifications used by {@link LocalPartitionNode}. */
+public abstract class PartitionFunctionSpec extends ISerializable {}

--- a/src/main/java/org/boostscale/velox4j/plan/partition/RoundRobinPartitionFunctionSpec.java
+++ b/src/main/java/org/boostscale/velox4j/plan/partition/RoundRobinPartitionFunctionSpec.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.plan.partition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/** Round-robin partition function that distributes data evenly across partitions. */
+public class RoundRobinPartitionFunctionSpec extends PartitionFunctionSpec {
+
+  @JsonCreator
+  public RoundRobinPartitionFunctionSpec() {}
+}

--- a/src/main/java/org/boostscale/velox4j/serializable/ISerializableRegistry.java
+++ b/src/main/java/org/boostscale/velox4j/serializable/ISerializableRegistry.java
@@ -30,12 +30,16 @@ import org.boostscale.velox4j.plan.AggregationNode;
 import org.boostscale.velox4j.plan.FilterNode;
 import org.boostscale.velox4j.plan.HashJoinNode;
 import org.boostscale.velox4j.plan.LimitNode;
+import org.boostscale.velox4j.plan.LocalPartitionNode;
 import org.boostscale.velox4j.plan.OrderByNode;
 import org.boostscale.velox4j.plan.ProjectNode;
 import org.boostscale.velox4j.plan.TableScanNode;
 import org.boostscale.velox4j.plan.TableWriteNode;
 import org.boostscale.velox4j.plan.ValuesNode;
 import org.boostscale.velox4j.plan.WindowNode;
+import org.boostscale.velox4j.plan.partition.GatherPartitionFunctionSpec;
+import org.boostscale.velox4j.plan.partition.HashPartitionFunctionSpec;
+import org.boostscale.velox4j.plan.partition.RoundRobinPartitionFunctionSpec;
 import org.boostscale.velox4j.query.Query;
 import org.boostscale.velox4j.serde.Serde;
 import org.boostscale.velox4j.serde.SerdeRegistry;
@@ -75,6 +79,7 @@ public final class ISerializableRegistry {
     registerConnectors();
     registerFilters();
     registerPlanNodes();
+    registerPartitionFunctionSpecs();
     registerConfig();
     registerEvaluation();
     registerQuery();
@@ -150,6 +155,14 @@ public final class ISerializableRegistry {
     NAME_REGISTRY.registerClass("LimitNode", LimitNode.class);
     NAME_REGISTRY.registerClass("TableWriteNode", TableWriteNode.class);
     NAME_REGISTRY.registerClass("WindowNode", WindowNode.class);
+    NAME_REGISTRY.registerClass("LocalPartitionNode", LocalPartitionNode.class);
+  }
+
+  private static void registerPartitionFunctionSpecs() {
+    NAME_REGISTRY.registerClass("GatherPartitionFunctionSpec", GatherPartitionFunctionSpec.class);
+    NAME_REGISTRY.registerClass("HashPartitionFunctionSpec", HashPartitionFunctionSpec.class);
+    NAME_REGISTRY.registerClass(
+        "RoundRobinPartitionFunctionSpec", RoundRobinPartitionFunctionSpec.class);
   }
 
   private static void registerConfig() {

--- a/src/test/java/org/boostscale/velox4j/serde/PlanNodeSerdeTest.java
+++ b/src/test/java/org/boostscale/velox4j/serde/PlanNodeSerdeTest.java
@@ -30,12 +30,16 @@ import org.boostscale.velox4j.plan.AggregationNode;
 import org.boostscale.velox4j.plan.FilterNode;
 import org.boostscale.velox4j.plan.HashJoinNode;
 import org.boostscale.velox4j.plan.LimitNode;
+import org.boostscale.velox4j.plan.LocalPartitionNode;
 import org.boostscale.velox4j.plan.OrderByNode;
 import org.boostscale.velox4j.plan.PlanNode;
 import org.boostscale.velox4j.plan.ProjectNode;
 import org.boostscale.velox4j.plan.TableWriteNode;
 import org.boostscale.velox4j.plan.ValuesNode;
 import org.boostscale.velox4j.plan.WindowNode;
+import org.boostscale.velox4j.plan.partition.GatherPartitionFunctionSpec;
+import org.boostscale.velox4j.plan.partition.HashPartitionFunctionSpec;
+import org.boostscale.velox4j.plan.partition.RoundRobinPartitionFunctionSpec;
 import org.boostscale.velox4j.session.Session;
 import org.boostscale.velox4j.sort.SortOrder;
 import org.boostscale.velox4j.test.Velox4jTests;
@@ -257,5 +261,50 @@ public class PlanNodeSerdeTest {
   public void testWindowNode() {
     final WindowNode windowNode = SerdeTests.newSampleWindowNode("id-1", "id-2");
     SerdeTests.testISerializableRoundTrip(windowNode);
+  }
+
+  @Test
+  public void testLocalPartitionNodeGather() {
+    final PlanNode scan =
+        SerdeTests.newSampleTableScanNode("id-1", SerdeTests.newSampleOutputType());
+    final LocalPartitionNode node =
+        new LocalPartitionNode(
+            "id-2",
+            LocalPartitionNode.Type.GATHER,
+            false,
+            new GatherPartitionFunctionSpec(),
+            ImmutableList.of(scan));
+    SerdeTests.testISerializableRoundTrip(node);
+  }
+
+  @Test
+  public void testLocalPartitionNodeRepartitionWithHash() {
+    final RowType inputType =
+        new RowType(
+            ImmutableList.of("foo1", "bar1"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
+    final PlanNode scan = SerdeTests.newSampleTableScanNode("id-1", inputType);
+    final LocalPartitionNode node =
+        new LocalPartitionNode(
+            "id-2",
+            LocalPartitionNode.Type.REPARTITION,
+            false,
+            new HashPartitionFunctionSpec(inputType, ImmutableList.of(0)),
+            ImmutableList.of(scan));
+    SerdeTests.testISerializableRoundTrip(node);
+  }
+
+  @Test
+  public void testLocalPartitionNodeRepartitionWithRoundRobin() {
+    final PlanNode scan =
+        SerdeTests.newSampleTableScanNode("id-1", SerdeTests.newSampleOutputType());
+    final LocalPartitionNode node =
+        new LocalPartitionNode(
+            "id-2",
+            LocalPartitionNode.Type.REPARTITION,
+            false,
+            new RoundRobinPartitionFunctionSpec(),
+            ImmutableList.of(scan));
+    SerdeTests.testISerializableRoundTrip(node);
   }
 }


### PR DESCRIPTION
PR Separated from https://github.com/boostscale/velox4j/pull/593, check the desc for details.
---
Exposes Velox's built-in `LocalPartitionNode` as a Java plan node for in-process data repartitioning. This enables MPP frameworks to express hash/gather/round-robin partitioning directly in the Velox plan tree instead of implementing partitioning outside Velox.

 - `LocalPartitionNode` with `GATHER` (N-to-1) and `REPARTITION` (N-to-M) modes
 - `PartitionFunctionSpec` hierarchy: `GatherPartitionFunctionSpec`, `HashPartitionFunctionSpec`,  `RoundRobinPartitionFunctionSpec`
 - No C++ changes needed — Velox already registers these types via `registerPartitionFunctionSerDe()` and  `PlanNode::registerSerDe()`

#### Data flow

<img width="3600" height="2880" alt="local-partition-flow" src="https://github.com/user-attachments/assets/c2f86356-ab46-490e-9cf6-db360c66a740" />