### PR TITLE
Bump Spotless and Google Java Format for JDK 21 compatibility

### DIFF
--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           docker exec al2023-container bash -c "
             export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
-            mvn clean test -Dskip.cpp.build -Dspotless.check.skip=true
+            mvn clean test -Dskip.cpp.build
           "
       - name: Stop Docker container
         run: |

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ sudo bash .github/workflows/scripts/common/setup-al2023.sh
 
 # 2. Set JAVA_HOME and build.
 export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
-mvn clean install -DskipTests -Dspotless.check.skip=true
+mvn clean install -DskipTests
 ```
 
 Alternatively, use Docker from any Linux machine:
@@ -154,11 +154,8 @@ docker run --init -it -v $(pwd):/velox4j -w /velox4j amazonlinux:2023 bash
 # Inside the container:
 export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
 bash .github/workflows/scripts/common/setup-al2023.sh
-mvn clean install -DskipTests -Dspotless.check.skip=true
+mvn clean install -DskipTests
 ```
-
-NOTE: The `-Dspotless.check.skip=true` flag is required when building with JDK 21
-because the Spotless code formatter plugin is not yet compatible with JDK 21.
 
 ## Get Started
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.30.0</version>
+        <version>2.43.0</version>
         <configuration>
           <upToDateChecking>
             <enabled>true</enabled>
@@ -212,7 +212,7 @@
               <include>src/test/java/**/*.java</include>
             </includes>
             <googleJavaFormat>
-              <version>1.7</version>
+              <version>1.22.0</version>
               <style>GOOGLE</style>
             </googleJavaFormat>
             <removeUnusedImports></removeUnusedImports>


### PR DESCRIPTION
Bump `spotless-maven-plugin` 2.30.0 → 2.43.0 and `google-java-format` 1.7 → 1.22.0.
The old GJF 1.7 uses internal JDK compiler APIs (`JCImport.getQualifiedIdentifier`) that changed in JDK 21, causing `spotless:check/apply` to crash with `InvocationTargetException`.

#### Compatibility
Both JDK11 and JDK21 work now.
Zero formatting changes.