### PR TITLE
Add thread safety to MemoryManager pool access

### DIFF
--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -54,7 +54,8 @@ jlong createEvaluator(JNIEnv* env, jobject javaThis, jstring evalJson) {
   auto session = sessionOf(env, javaThis);
   spotify::jni::JavaString jExprJson{env, evalJson};
   auto evaluationSerdePool = session->memoryManager()->getVeloxPool(
-      "Evaluation Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Evaluation Serde Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   auto exprDynamic = folly::parseJson(jExprJson.get());
   auto evaluation =
       ISerializable::deserialize<Evaluation>(exprDynamic, evaluationSerdePool);
@@ -86,7 +87,8 @@ jlong createQueryExecutor(JNIEnv* env, jobject javaThis, jstring queryJson) {
   auto session = sessionOf(env, javaThis);
   spotify::jni::JavaString jQueryJson{env, queryJson};
   auto querySerdePool = session->memoryManager()->getVeloxPool(
-      fmt::format("Query Serde Memory Pool"), memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Query Serde Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   // Keep the pool alive until the task is finished.
   auto queryDynamic = folly::parseJson(jQueryJson.get());
   auto query = ISerializable::deserialize<Query>(queryDynamic, querySerdePool);
@@ -142,7 +144,8 @@ void typeToArrow(
   auto dynamic = folly::parseJson(jTypeJson.get());
   auto type = Type::create(dynamic);
   auto typePool = session->memoryManager()->getVeloxPool(
-      "Type Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Type Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   fromTypeToArrow(
       typePool, type, reinterpret_cast<struct ArrowSchema*>(cSchema));
   JNI_METHOD_END()
@@ -155,7 +158,8 @@ jlong createEmptyBaseVector(JNIEnv* env, jobject javaThis, jstring typeJson) {
   auto dynamic = folly::parseJson(jTypeJson.get());
   auto type = Type::create(dynamic);
   auto vectorPool = session->memoryManager()->getVeloxPool(
-      "BaseVector Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("BaseVector Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   auto vector = BaseVector::create(type, 0, vectorPool);
   return session->objectStore()->save(vector);
   JNI_METHOD_END(-1L)
@@ -170,7 +174,8 @@ jlong arrowToBaseVector(
   // TODO Session memory pool.
   auto session = sessionOf(env, javaThis);
   auto pool = session->memoryManager()->getVeloxPool(
-      "Arrow Import Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Arrow Import Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   auto vector = fromArrowToBaseVector(
       pool,
       reinterpret_cast<struct ArrowSchema*>(cSchema),
@@ -187,7 +192,8 @@ baseVectorDeserialize(JNIEnv* env, jobject javaThis, jstring serialized) {
   auto decoded = encoding::Base64::decode(jSerialized.get());
   std::istringstream dataStream(decoded);
   auto pool = session->memoryManager()->getVeloxPool(
-      "Decoding Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Decoding Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   std::vector<ObjectHandle> vids{};
   while (dataStream.tellg() < decoded.size()) {
     const VectorPtr& vector = restoreVector(dataStream, pool);
@@ -267,7 +273,8 @@ jlongArray rowVectorPartitionByKeys(
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   auto pool = session->memoryManager()->getVeloxPool(
-      "Partition By Keys Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Partition By Keys Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   const auto inputRowVector = ObjectStore::retrieve<RowVector>(vid);
   const auto inputNumRows = inputRowVector->size();
 
@@ -351,7 +358,8 @@ jstring tableWriteTraitsOutputTypeFromColumnStatsSpec(
   spotify::jni::JavaString jJson{env, columnStatsSpecJson};
   auto dynamic = folly::parseJson(jJson.get());
   auto serdePool = session->memoryManager()->getVeloxPool(
-      "Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Serde Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   auto columnStatSpec = core::ColumnStatsSpec::create(dynamic, serdePool);
   auto type = exec::TableWriteTraits::outputType(columnStatSpec);
   auto serializedDynamic = type->serialize();
@@ -364,7 +372,8 @@ jlong iSerializableAsCpp(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   auto serdePool = session->memoryManager()->getVeloxPool(
-      "Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("Serde Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   spotify::jni::JavaString jJson{env, json};
   auto dynamic = folly::parseJson(jJson.get());
   auto deserialized = std::const_pointer_cast<ISerializable>(
@@ -391,7 +400,8 @@ jlong variantToVector(
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   auto vectorPool = session->memoryManager()->getVeloxPool(
-      "BaseVector Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      session->memoryManager()->uniquePoolName("BaseVector Memory Pool"),
+      memory::MemoryPool::Kind::kLeaf);
   spotify::jni::JavaString jTypeJson{env, typeJson};
   spotify::jni::JavaString jVariantJson{env, variantJson};
   auto type = Type::create(folly::parseJson(jTypeJson.get()));

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -86,7 +86,7 @@ jlong createQueryExecutor(JNIEnv* env, jobject javaThis, jstring queryJson) {
   auto session = sessionOf(env, javaThis);
   spotify::jni::JavaString jQueryJson{env, queryJson};
   auto querySerdePool = session->memoryManager()->getVeloxPool(
-      "Query Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
+      fmt::format("Query Serde Memory Pool"), memory::MemoryPool::Kind::kLeaf);
   // Keep the pool alive until the task is finished.
   auto queryDynamic = folly::parseJson(jQueryJson.get());
   auto query = ISerializable::deserialize<Query>(queryDynamic, querySerdePool);

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -54,8 +54,7 @@ jlong createEvaluator(JNIEnv* env, jobject javaThis, jstring evalJson) {
   auto session = sessionOf(env, javaThis);
   spotify::jni::JavaString jExprJson{env, evalJson};
   auto evaluationSerdePool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Evaluation Serde Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Evaluation Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
   auto exprDynamic = folly::parseJson(jExprJson.get());
   auto evaluation =
       ISerializable::deserialize<Evaluation>(exprDynamic, evaluationSerdePool);
@@ -87,8 +86,7 @@ jlong createQueryExecutor(JNIEnv* env, jobject javaThis, jstring queryJson) {
   auto session = sessionOf(env, javaThis);
   spotify::jni::JavaString jQueryJson{env, queryJson};
   auto querySerdePool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Query Serde Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Query Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
   // Keep the pool alive until the task is finished.
   auto queryDynamic = folly::parseJson(jQueryJson.get());
   auto query = ISerializable::deserialize<Query>(queryDynamic, querySerdePool);
@@ -144,8 +142,7 @@ void typeToArrow(
   auto dynamic = folly::parseJson(jTypeJson.get());
   auto type = Type::create(dynamic);
   auto typePool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Type Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Type Memory Pool", memory::MemoryPool::Kind::kLeaf);
   fromTypeToArrow(
       typePool, type, reinterpret_cast<struct ArrowSchema*>(cSchema));
   JNI_METHOD_END()
@@ -158,8 +155,7 @@ jlong createEmptyBaseVector(JNIEnv* env, jobject javaThis, jstring typeJson) {
   auto dynamic = folly::parseJson(jTypeJson.get());
   auto type = Type::create(dynamic);
   auto vectorPool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("BaseVector Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "BaseVector Memory Pool", memory::MemoryPool::Kind::kLeaf);
   auto vector = BaseVector::create(type, 0, vectorPool);
   return session->objectStore()->save(vector);
   JNI_METHOD_END(-1L)
@@ -174,8 +170,7 @@ jlong arrowToBaseVector(
   // TODO Session memory pool.
   auto session = sessionOf(env, javaThis);
   auto pool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Arrow Import Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Arrow Import Memory Pool", memory::MemoryPool::Kind::kLeaf);
   auto vector = fromArrowToBaseVector(
       pool,
       reinterpret_cast<struct ArrowSchema*>(cSchema),
@@ -192,8 +187,7 @@ baseVectorDeserialize(JNIEnv* env, jobject javaThis, jstring serialized) {
   auto decoded = encoding::Base64::decode(jSerialized.get());
   std::istringstream dataStream(decoded);
   auto pool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Decoding Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Decoding Memory Pool", memory::MemoryPool::Kind::kLeaf);
   std::vector<ObjectHandle> vids{};
   while (dataStream.tellg() < decoded.size()) {
     const VectorPtr& vector = restoreVector(dataStream, pool);
@@ -273,8 +267,7 @@ jlongArray rowVectorPartitionByKeys(
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   auto pool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Partition By Keys Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Partition By Keys Memory Pool", memory::MemoryPool::Kind::kLeaf);
   const auto inputRowVector = ObjectStore::retrieve<RowVector>(vid);
   const auto inputNumRows = inputRowVector->size();
 
@@ -358,8 +351,7 @@ jstring tableWriteTraitsOutputTypeFromColumnStatsSpec(
   spotify::jni::JavaString jJson{env, columnStatsSpecJson};
   auto dynamic = folly::parseJson(jJson.get());
   auto serdePool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Serde Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
   auto columnStatSpec = core::ColumnStatsSpec::create(dynamic, serdePool);
   auto type = exec::TableWriteTraits::outputType(columnStatSpec);
   auto serializedDynamic = type->serialize();
@@ -372,8 +364,7 @@ jlong iSerializableAsCpp(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   auto serdePool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("Serde Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "Serde Memory Pool", memory::MemoryPool::Kind::kLeaf);
   spotify::jni::JavaString jJson{env, json};
   auto dynamic = folly::parseJson(jJson.get());
   auto deserialized = std::const_pointer_cast<ISerializable>(
@@ -400,8 +391,7 @@ jlong variantToVector(
   JNI_METHOD_START
   auto session = sessionOf(env, javaThis);
   auto vectorPool = session->memoryManager()->getVeloxPool(
-      session->memoryManager()->uniquePoolName("BaseVector Memory Pool"),
-      memory::MemoryPool::Kind::kLeaf);
+      "BaseVector Memory Pool", memory::MemoryPool::Kind::kLeaf);
   spotify::jni::JavaString jTypeJson{env, typeJson};
   spotify::jni::JavaString jVariantJson{env, variantJson};
   auto type = Type::create(folly::parseJson(jTypeJson.get()));

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.cc
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.cc
@@ -362,6 +362,7 @@ MemoryManager::~MemoryManager() {
 velox::memory::MemoryPool* MemoryManager::getVeloxPool(
     const std::string& name,
     const velox::memory::MemoryPool::Kind& kind) {
+  std::lock_guard<std::mutex> guard(poolMutex_);
   if (veloxPoolRefs_.count(name) > 0) {
     const auto& pool = veloxPoolRefs_[name];
     VELOX_CHECK_EQ(
@@ -389,6 +390,10 @@ velox::memory::MemoryPool* MemoryManager::getVeloxPool(
     }
   }
   VELOX_FAIL("Unreachable code");
+}
+
+std::string MemoryManager::uniquePoolName(const std::string& baseName) {
+  return fmt::format("{} #{}", baseName, poolIdCounter_++);
 }
 
 arrow::MemoryPool* MemoryManager::getArrowPool(const std::string& name) {

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.cc
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.cc
@@ -392,11 +392,8 @@ velox::memory::MemoryPool* MemoryManager::getVeloxPool(
   VELOX_FAIL("Unreachable code");
 }
 
-std::string MemoryManager::uniquePoolName(const std::string& baseName) {
-  return fmt::format("{} #{}", baseName, poolIdCounter_++);
-}
-
 arrow::MemoryPool* MemoryManager::getArrowPool(const std::string& name) {
+  std::lock_guard<std::mutex> guard(poolMutex_);
   if (arrowPoolRefs_.count(name) > 0) {
     return arrowPoolRefs_[name].get();
   }

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.h
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.h
@@ -17,7 +17,6 @@
 #include <arrow/memory_pool.h>
 #include <velox/common/config/Config.h>
 #include <velox/common/memory/Memory.h>
-#include <atomic>
 #include <memory>
 #include <mutex>
 #include "velox4j/memory/AllocationListener.h"
@@ -44,11 +43,6 @@ class MemoryManager {
 
   arrow::MemoryPool* getArrowPool(const std::string& name);
 
-  /// Generate a unique pool name by appending an atomic counter suffix.
-  /// This avoids "Leaf child memory pool already exists" collisions when
-  /// multiple sessions or concurrent JNI calls use the same MemoryManager.
-  std::string uniquePoolName(const std::string& baseName);
-
  private:
   bool tryDestruct();
 
@@ -63,6 +57,5 @@ class MemoryManager {
       std::shared_ptr<facebook::velox::memory::MemoryPool>>
       veloxPoolRefs_;
   mutable std::mutex poolMutex_;
-  std::atomic<uint64_t> poolIdCounter_{0};
 };
 } // namespace velox4j

--- a/src/main/cpp/main/velox4j/memory/MemoryManager.h
+++ b/src/main/cpp/main/velox4j/memory/MemoryManager.h
@@ -17,7 +17,9 @@
 #include <arrow/memory_pool.h>
 #include <velox/common/config/Config.h>
 #include <velox/common/memory/Memory.h>
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include "velox4j/memory/AllocationListener.h"
 #include "velox4j/memory/ArrowMemoryPool.h"
 
@@ -42,6 +44,11 @@ class MemoryManager {
 
   arrow::MemoryPool* getArrowPool(const std::string& name);
 
+  /// Generate a unique pool name by appending an atomic counter suffix.
+  /// This avoids "Leaf child memory pool already exists" collisions when
+  /// multiple sessions or concurrent JNI calls use the same MemoryManager.
+  std::string uniquePoolName(const std::string& baseName);
+
  private:
   bool tryDestruct();
 
@@ -55,5 +62,7 @@ class MemoryManager {
       std::string,
       std::shared_ptr<facebook::velox::memory::MemoryPool>>
       veloxPoolRefs_;
+  mutable std::mutex poolMutex_;
+  std::atomic<uint64_t> poolIdCounter_{0};
 };
 } // namespace velox4j

--- a/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
+++ b/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.memory;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.boostscale.velox4j.Velox4j;
+import org.boostscale.velox4j.config.Config;
+import org.boostscale.velox4j.config.ConnectorConfig;
+import org.boostscale.velox4j.connector.ExternalStreamConnectorSplit;
+import org.boostscale.velox4j.connector.ExternalStreamTableHandle;
+import org.boostscale.velox4j.connector.ExternalStreams;
+import org.boostscale.velox4j.data.BaseVectorTests;
+import org.boostscale.velox4j.data.RowVector;
+import org.boostscale.velox4j.iterator.CloseableIterator;
+import org.boostscale.velox4j.iterator.UpIterators;
+import org.boostscale.velox4j.plan.TableScanNode;
+import org.boostscale.velox4j.query.Query;
+import org.boostscale.velox4j.query.SerialTask;
+import org.boostscale.velox4j.session.Session;
+import org.boostscale.velox4j.test.SampleQueryTests;
+import org.boostscale.velox4j.test.Velox4jTests;
+import org.boostscale.velox4j.type.RowType;
+
+/**
+ * Tests that multiple sequential query executions on the same MemoryManager do not crash with "Leaf
+ * child memory pool X already exists in root".
+ *
+ * <p>Before the fix, JNI functions used hardcoded pool names (e.g. "Arrow Import Memory Pool",
+ * "Query Serde Memory Pool"). When a second query (or a second Session sharing the same
+ * MemoryManager) called the same JNI function, Velox's addLeafChild() threw because the name was
+ * already registered.
+ *
+ * <p>The fix uses MemoryManager::uniquePoolName() to append an atomic counter suffix, ensuring each
+ * pool gets a unique name like "Arrow Import Memory Pool #0", "#1", etc.
+ */
+public class MemoryPoolNameCollisionTest {
+
+  private static BytesAllocationListener allocationListener;
+  private static MemoryManager memoryManager;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Velox4jTests.ensureInitialized();
+    allocationListener = new BytesAllocationListener();
+    memoryManager = Velox4j.newMemoryManager(allocationListener);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
+  }
+
+  /**
+   * Run multiple queries sequentially on the same MemoryManager using different Sessions. This
+   * simulates the OpenSearch OLAP plugin pattern where each query gets a new Session but shares the
+   * MemoryManager.
+   *
+   * <p>Before the fix, the second query would crash with: "Leaf child memory pool Query Serde
+   * Memory Pool already exists in root"
+   */
+  @Test
+  public void testMultipleQueriesOnSameMemoryManager() {
+    for (int i = 0; i < 5; i++) {
+      Session session = Velox4j.newSession(memoryManager);
+      try {
+        runSimpleQuery(session);
+      } finally {
+        session.close();
+      }
+    }
+  }
+
+  /**
+   * Run multiple queries sequentially on the same Session. Tests that pool name uniqueness works
+   * within a single session too.
+   */
+  @Test
+  public void testMultipleQueriesOnSameSession() {
+    Session session = Velox4j.newSession(memoryManager);
+    try {
+      for (int i = 0; i < 5; i++) {
+        runSimpleQuery(session);
+      }
+    } finally {
+      session.close();
+    }
+  }
+
+  /**
+   * Run multiple queries concurrently on the same MemoryManager from different threads. Tests
+   * thread safety of pool creation.
+   */
+  @Test
+  public void testConcurrentQueriesOnSameMemoryManager() throws InterruptedException {
+    final int numThreads = 4;
+    Thread[] threads = new Thread[numThreads];
+    final Throwable[] errors = new Throwable[numThreads];
+
+    for (int t = 0; t < numThreads; t++) {
+      final int threadIdx = t;
+      threads[t] =
+          new Thread(
+              () -> {
+                Session session = Velox4j.newSession(memoryManager);
+                try {
+                  for (int i = 0; i < 3; i++) {
+                    runSimpleQuery(session);
+                  }
+                } catch (Throwable e) {
+                  errors[threadIdx] = e;
+                } finally {
+                  session.close();
+                }
+              },
+              "pool-collision-test-" + t);
+      threads[t].start();
+    }
+
+    for (Thread thread : threads) {
+      thread.join(30_000);
+    }
+
+    for (int t = 0; t < numThreads; t++) {
+      if (errors[t] != null) {
+        Assert.fail("Thread " + t + " failed: " + errors[t].getMessage());
+      }
+    }
+  }
+
+  /**
+   * Run multiple Arrow import operations (arrowToBaseVector path) on the same MemoryManager. The
+   * "Arrow Import Memory Pool" was one of the most common collision points.
+   */
+  @Test
+  public void testMultipleArrowImportsOnSameMemoryManager() {
+    for (int i = 0; i < 5; i++) {
+      Session session = Velox4j.newSession(memoryManager);
+      try {
+        runArrowRoundTrip(session);
+      } finally {
+        session.close();
+      }
+    }
+  }
+
+  private void runSimpleQuery(Session session) {
+    RowType schema = SampleQueryTests.getSchema();
+    ExternalStreams.BlockingQueue queue = session.externalStreamOps().newBlockingQueue();
+    TableScanNode scanNode =
+        new TableScanNode(
+            "scan-1",
+            schema,
+            new ExternalStreamTableHandle("connector-external-stream"),
+            ImmutableList.of());
+    Query query = new Query(scanNode, Config.empty(), ConnectorConfig.empty());
+    SerialTask task = session.queryOps().execute(query);
+    task.addSplit(
+        scanNode.getId(),
+        new ExternalStreamConnectorSplit("connector-external-stream", queue.id()));
+    task.noMoreSplits(scanNode.getId());
+
+    RowVector rv = BaseVectorTests.newSampleRowVector(session);
+    queue.put(rv);
+    queue.noMoreInput();
+
+    CloseableIterator<RowVector> iter = UpIterators.asJavaIterator(task);
+    int count = 0;
+    while (iter.hasNext()) {
+      RowVector result = iter.next();
+      Assert.assertNotNull(result);
+      count++;
+    }
+    iter.close();
+    Assert.assertTrue("Expected at least 1 result batch", count > 0);
+  }
+
+  private void runArrowRoundTrip(Session session) {
+    RowVector rv = BaseVectorTests.newSampleRowVector(session);
+    org.apache.arrow.memory.BufferAllocator allocator =
+        new org.apache.arrow.memory.RootAllocator(Long.MAX_VALUE);
+    try {
+      // Velox → Arrow (uses toArrowVectorSchemaRoot internally)
+      org.apache.arrow.vector.VectorSchemaRoot arrowRoot =
+          org.boostscale.velox4j.arrow.Arrow.toArrowVectorSchemaRoot(allocator, rv);
+      Assert.assertNotNull(arrowRoot);
+      Assert.assertTrue(arrowRoot.getRowCount() > 0);
+
+      // Arrow → Velox (uses "Arrow Import Memory Pool" path)
+      RowVector roundTripped = session.arrowOps().fromArrowVectorSchemaRoot(allocator, arrowRoot);
+      Assert.assertNotNull(roundTripped);
+      Assert.assertEquals(rv.getSize(), roundTripped.getSize());
+
+      arrowRoot.close();
+    } finally {
+      allocator.close();
+    }
+  }
+}

--- a/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
+++ b/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
@@ -42,16 +42,12 @@ import org.boostscale.velox4j.test.Velox4jTests;
 import org.boostscale.velox4j.type.RowType;
 
 /**
- * Tests that multiple sequential query executions on the same MemoryManager do not crash with "Leaf
- * child memory pool X already exists in root".
+ * Tests that shared memory pools in MemoryManager work correctly across multiple sequential and
+ * concurrent sessions.
  *
- * <p>Before the fix, JNI functions used hardcoded pool names (e.g. "Arrow Import Memory Pool",
- * "Query Serde Memory Pool"). When a second query (or a second Session sharing the same
- * MemoryManager) called the same JNI function, Velox's addLeafChild() threw because the name was
- * already registered.
- *
- * <p>The fix uses MemoryManager::uniquePoolName() to append an atomic counter suffix, ensuring each
- * pool gets a unique name like "Arrow Import Memory Pool #0", "#1", etc.
+ * <p>Memory pools are intentionally shared by name (e.g. "Query Serde Memory Pool") across calls to
+ * avoid creation overhead. Thread safety is ensured by {@code std::lock_guard} in {@code
+ * getVeloxPool()} and {@code getArrowPool()}.
  */
 public class MemoryPoolNameCollisionTest {
 
@@ -72,12 +68,8 @@ public class MemoryPoolNameCollisionTest {
   }
 
   /**
-   * Run multiple queries sequentially on the same MemoryManager using different Sessions. This
-   * simulates the OpenSearch OLAP plugin pattern where each query gets a new Session but shares the
-   * MemoryManager.
-   *
-   * <p>Before the fix, the second query would crash with: "Leaf child memory pool Query Serde
-   * Memory Pool already exists in root"
+   * Run multiple queries sequentially on the same MemoryManager using different Sessions. Verifies
+   * that shared memory pools are correctly reused across sessions.
    */
   @Test
   public void testMultipleQueriesOnSameMemoryManager() throws Exception {
@@ -91,10 +83,7 @@ public class MemoryPoolNameCollisionTest {
     }
   }
 
-  /**
-   * Run multiple queries sequentially on the same Session. Tests that pool name uniqueness works
-   * within a single session too.
-   */
+  /** Run multiple queries sequentially on the same Session. Tests pool reuse within a session. */
   @Test
   public void testMultipleQueriesOnSameSession() throws Exception {
     Session session = Velox4j.newSession(memoryManager);
@@ -148,10 +137,7 @@ public class MemoryPoolNameCollisionTest {
     }
   }
 
-  /**
-   * Run multiple Arrow import operations (arrowToBaseVector path) on the same MemoryManager. The
-   * "Arrow Import Memory Pool" was one of the most common collision points.
-   */
+  /** Run multiple Arrow import operations on the same MemoryManager across different sessions. */
   @Test
   public void testMultipleArrowImportsOnSameMemoryManager() {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);

--- a/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
+++ b/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
@@ -76,7 +76,7 @@ public class MemoryPoolNameCollisionTest {
    * Memory Pool already exists in root"
    */
   @Test
-  public void testMultipleQueriesOnSameMemoryManager() {
+  public void testMultipleQueriesOnSameMemoryManager() throws Exception {
     for (int i = 0; i < 5; i++) {
       Session session = Velox4j.newSession(memoryManager);
       try {
@@ -92,7 +92,7 @@ public class MemoryPoolNameCollisionTest {
    * within a single session too.
    */
   @Test
-  public void testMultipleQueriesOnSameSession() {
+  public void testMultipleQueriesOnSameSession() throws Exception {
     Session session = Velox4j.newSession(memoryManager);
     try {
       for (int i = 0; i < 5; i++) {
@@ -160,7 +160,7 @@ public class MemoryPoolNameCollisionTest {
     }
   }
 
-  private void runSimpleQuery(Session session) {
+  private void runSimpleQuery(Session session) throws Exception {
     RowType schema = SampleQueryTests.getSchema();
     ExternalStreams.BlockingQueue queue = session.externalStreamOps().newBlockingQueue();
     TableScanNode scanNode =

--- a/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
+++ b/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
@@ -14,12 +14,16 @@
 package org.boostscale.velox4j.memory;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.boostscale.velox4j.Velox4j;
+import org.boostscale.velox4j.arrow.Arrow;
 import org.boostscale.velox4j.config.Config;
 import org.boostscale.velox4j.config.ConnectorConfig;
 import org.boostscale.velox4j.connector.ExternalStreamConnectorSplit;
@@ -150,13 +154,18 @@ public class MemoryPoolNameCollisionTest {
    */
   @Test
   public void testMultipleArrowImportsOnSameMemoryManager() {
-    for (int i = 0; i < 5; i++) {
-      Session session = Velox4j.newSession(memoryManager);
-      try {
-        runArrowRoundTrip(session);
-      } finally {
-        session.close();
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    try {
+      for (int i = 0; i < 5; i++) {
+        Session session = Velox4j.newSession(memoryManager);
+        try {
+          runArrowRoundTrip(session, allocator);
+        } finally {
+          session.close();
+        }
       }
+    } finally {
+      allocator.close();
     }
   }
 
@@ -191,25 +200,19 @@ public class MemoryPoolNameCollisionTest {
     Assert.assertTrue("Expected at least 1 result batch", count > 0);
   }
 
-  private void runArrowRoundTrip(Session session) {
+  private void runArrowRoundTrip(Session session, BufferAllocator allocator) {
     RowVector rv = BaseVectorTests.newSampleRowVector(session);
-    org.apache.arrow.memory.BufferAllocator allocator =
-        new org.apache.arrow.memory.RootAllocator(Long.MAX_VALUE);
-    try {
-      // Velox → Arrow (uses toArrowVectorSchemaRoot internally)
-      org.apache.arrow.vector.VectorSchemaRoot arrowRoot =
-          org.boostscale.velox4j.arrow.Arrow.toArrowVectorSchemaRoot(allocator, rv);
-      Assert.assertNotNull(arrowRoot);
-      Assert.assertTrue(arrowRoot.getRowCount() > 0);
 
-      // Arrow → Velox (uses "Arrow Import Memory Pool" path)
-      RowVector roundTripped = session.arrowOps().fromArrowVectorSchemaRoot(allocator, arrowRoot);
-      Assert.assertNotNull(roundTripped);
-      Assert.assertEquals(rv.getSize(), roundTripped.getSize());
+    // Velox → Arrow (uses toArrowVectorSchemaRoot internally)
+    VectorSchemaRoot arrowRoot = Arrow.toArrowVectorSchemaRoot(allocator, rv);
+    Assert.assertNotNull(arrowRoot);
+    Assert.assertTrue(arrowRoot.getRowCount() > 0);
 
-      arrowRoot.close();
-    } finally {
-      allocator.close();
-    }
+    // Arrow → Velox (uses "Arrow Import Memory Pool" path)
+    RowVector roundTripped = session.arrowOps().fromArrowVectorSchemaRoot(allocator, arrowRoot);
+    Assert.assertNotNull(roundTripped);
+    Assert.assertEquals(rv.getSize(), roundTripped.getSize());
+
+    arrowRoot.close();
   }
 }


### PR DESCRIPTION
### Problem

When multiple sessions share a `MemoryManager` (e.g. one MemoryManager per application, one session per query), concurrent JNI calls could race on the unprotected `veloxPoolRefs_` and `arrowPoolRefs_` maps, causing crashes or duplicate pool creation errors.

### Fix

Memory pools are intentionally shared by name across calls to avoid creation overhead. `getVeloxPool()` already had a `count > 0` check to return existing pools, but lacked a lock for thread safety. `getArrowPool()` had neither.

The fix adds `std::mutex poolMutex_` and guards both methods with `std::lock_guard`.