### PR TITLE
Make `PlanNode.getSources()` public for plan traversing

### DIFF
--- a/src/main/java/org/boostscale/velox4j/plan/AbstractJoinNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/AbstractJoinNode.java
@@ -50,7 +50,7 @@ public abstract class AbstractJoinNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 

--- a/src/main/java/org/boostscale/velox4j/plan/AggregationNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/AggregationNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -65,7 +66,7 @@ public class AggregationNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("step")

--- a/src/main/java/org/boostscale/velox4j/plan/FilterNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/FilterNode.java
@@ -36,7 +36,7 @@ public class FilterNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 

--- a/src/main/java/org/boostscale/velox4j/plan/FilterNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/FilterNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -37,7 +38,7 @@ public class FilterNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("filter")

--- a/src/main/java/org/boostscale/velox4j/plan/LimitNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/LimitNode.java
@@ -40,7 +40,7 @@ public class LimitNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 

--- a/src/main/java/org/boostscale/velox4j/plan/LimitNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/LimitNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -41,7 +42,7 @@ public class LimitNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("offset")

--- a/src/main/java/org/boostscale/velox4j/plan/LocalPartitionNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/LocalPartitionNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -73,7 +74,7 @@ public class LocalPartitionNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("type")

--- a/src/main/java/org/boostscale/velox4j/plan/LocalPartitionNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/LocalPartitionNode.java
@@ -72,7 +72,7 @@ public class LocalPartitionNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 

--- a/src/main/java/org/boostscale/velox4j/plan/OrderByNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/OrderByNode.java
@@ -43,7 +43,7 @@ public class OrderByNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 

--- a/src/main/java/org/boostscale/velox4j/plan/OrderByNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/OrderByNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,7 +45,7 @@ public class OrderByNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("sortingKeys")

--- a/src/main/java/org/boostscale/velox4j/plan/PlanNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/PlanNode.java
@@ -34,5 +34,5 @@ public abstract class PlanNode extends ISerializable {
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonGetter("sources")
-  protected abstract List<PlanNode> getSources();
+  public abstract List<PlanNode> getSources();
 }

--- a/src/main/java/org/boostscale/velox4j/plan/ProjectNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/ProjectNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,7 +41,7 @@ public class ProjectNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("names")

--- a/src/main/java/org/boostscale/velox4j/plan/ProjectNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/ProjectNode.java
@@ -39,7 +39,7 @@ public class ProjectNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 

--- a/src/main/java/org/boostscale/velox4j/plan/TableScanNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/TableScanNode.java
@@ -57,7 +57,7 @@ public class TableScanNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return Collections.emptyList();
   }
 }

--- a/src/main/java/org/boostscale/velox4j/plan/TableWriteNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/TableWriteNode.java
@@ -102,7 +102,7 @@ public class TableWriteNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return sources;
   }
 }

--- a/src/main/java/org/boostscale/velox4j/plan/TableWriteNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/TableWriteNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -103,6 +104,6 @@ public class TableWriteNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 }

--- a/src/main/java/org/boostscale/velox4j/plan/ValuesNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/ValuesNode.java
@@ -62,7 +62,7 @@ public class ValuesNode extends PlanNode {
   }
 
   @Override
-  protected List<PlanNode> getSources() {
+  public List<PlanNode> getSources() {
     return ImmutableList.of();
   }
 }

--- a/src/main/java/org/boostscale/velox4j/plan/WindowNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/WindowNode.java
@@ -13,6 +13,7 @@
  */
 package org.boostscale.velox4j.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -55,7 +56,7 @@ public class WindowNode extends PlanNode {
 
   @Override
   public List<PlanNode> getSources() {
-    return sources;
+    return Collections.unmodifiableList(sources);
   }
 
   @JsonGetter("partitionKeys")


### PR DESCRIPTION
This makes `getSources()` accessible from outside the plan package, which is needed if external code (e.g., a framework using velox4j) wants to traverse the plan tree. The @JsonGetter("sources") annotation stays the same so serialization is unaffected.