### PR TITLE
test/CMakeLists.txt cleanup

### DIFF
--- a/src/main/cpp/test/CMakeLists.txt
+++ b/src/main/cpp/test/CMakeLists.txt
@@ -13,20 +13,6 @@ target_link_libraries(
     velox_test_util
     velox_exec_test_lib)
 
-# velox_rpc_node_test (from Velox) includes <gmock/gmock.h> but its upstream
-# CMakeLists.txt omits GTest::gmock from its link libraries, so the gmock
-# headers are never added to the include path. Add the missing dependency here.
-if(TARGET velox_rpc_node_test)
-  target_link_libraries(velox_rpc_node_test GTest::gmock)
-endif()
-
-# velox_hive_connector_test (from Velox) includes <gmock/gmock.h> but its
-# upstream CMakeLists.txt omits GTest::gmock from its link libraries, so the
-# gmock headers are never added to the include path. Add the missing dependency
-# here.
-if(TARGET velox_hive_connector_test)
-  target_link_libraries(velox_hive_connector_test GTest::gmock)
-endif()
 set(TEST_OBJECT_FILES $<TARGET_OBJECTS:velox_fuzzer_connector>)
 
 add_executable(velox4j_query_serde_test ${TEST_OBJECT_FILES}


### PR DESCRIPTION
Verify whether we still need the 2 gmock dependency hacks.