### PR TITLE
Add PlanNode.toFormatString() to display Velox's readable plan tree

### DIFF
--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -15,6 +15,7 @@
 #include "velox4j/jni/StaticJniWrapper.h"
 #include <folly/json/json.h>
 #include <velox/common/encode/Base64.h>
+#include <velox/core/PlanNode.h>
 #include <velox/exec/TableWriter.h>
 #include <velox/vector/VectorSaver.h>
 
@@ -260,6 +261,23 @@ selectivityVectorIsValid(JNIEnv* env, jobject javaThis, jlong svId, jint idx) {
   JNI_METHOD_END(false)
 }
 
+jstring planNodeToString(
+    JNIEnv* env,
+    jobject javaThis,
+    jlong id,
+    jboolean detailed,
+    jboolean recursive) {
+  JNI_METHOD_START
+  auto iSerializable = ObjectStore::retrieve<ISerializable>(id);
+  auto planNode =
+      std::dynamic_pointer_cast<const core::PlanNode>(iSerializable);
+  VELOX_CHECK_NOT_NULL(
+      planNode, "Object is not a PlanNode: {}", typeid(*iSerializable).name());
+  auto str = planNode->toString(detailed, recursive);
+  return env->NewStringUTF(str.data());
+  JNI_METHOD_END(nullptr)
+}
+
 jstring iSerializableAsJava(JNIEnv* env, jobject javaThis, jlong id) {
   JNI_METHOD_START
   auto iSerializable = ObjectStore::retrieve<ISerializable>(id);
@@ -431,6 +449,14 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       "tableWriteTraitsOutputType",
       (void*)tableWriteTraitsOutputType,
       kTypeString,
+      nullptr);
+  addNativeMethod(
+      "planNodeToString",
+      (void*)planNodeToString,
+      kTypeString,
+      kTypeLong,
+      kTypeBool,
+      kTypeBool,
       nullptr);
   addNativeMethod(
       "iSerializableAsJava",

--- a/src/main/java/org/boostscale/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/org/boostscale/velox4j/jni/StaticJniApi.java
@@ -152,6 +152,10 @@ public class StaticJniApi {
     return type;
   }
 
+  public String planNodeToString(CppObject planNodeCo, boolean detailed, boolean recursive) {
+    return jni.planNodeToString(planNodeCo.id(), detailed, recursive);
+  }
+
   public ISerializable iSerializableAsJava(ISerializableCo co) {
     final String json = jni.iSerializableAsJava(co.id());
     return Serde.fromJson(json, ISerializable.class);

--- a/src/main/java/org/boostscale/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/org/boostscale/velox4j/jni/StaticJniWrapper.java
@@ -84,6 +84,9 @@ public class StaticJniWrapper {
   // For TableWrite.
   native String tableWriteTraitsOutputType();
 
+  // For PlanNode.
+  native String planNodeToString(long id, boolean detailed, boolean recursive);
+
   // For serde.
   native String iSerializableAsJava(long id);
 

--- a/src/main/java/org/boostscale/velox4j/plan/PlanNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/PlanNode.java
@@ -18,7 +18,10 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import org.boostscale.velox4j.jni.StaticJniApi;
 import org.boostscale.velox4j.serializable.ISerializable;
+import org.boostscale.velox4j.serializable.ISerializableCo;
+import org.boostscale.velox4j.session.Session;
 
 public abstract class PlanNode extends ISerializable {
   private final String id;
@@ -35,4 +38,17 @@ public abstract class PlanNode extends ISerializable {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @JsonGetter("sources")
   public abstract List<PlanNode> getSources();
+
+  /**
+   * Returns a human-readable string representation of this plan tree using Velox's C++ formatting.
+   *
+   * @param session the session used to send the plan to C++ for formatting
+   * @param detailed if true, includes node-specific details (expressions, join keys, etc.)
+   * @param recursive if true, includes the entire subtree; otherwise just this node
+   */
+  public String toFormatString(Session session, boolean detailed, boolean recursive) {
+    try (ISerializableCo co = session.iSerializableOps().asCpp(this)) {
+      return StaticJniApi.get().planNodeToString(co, detailed, recursive);
+    }
+  }
 }

--- a/src/test/java/org/boostscale/velox4j/plan/PlanNodeToStringTest.java
+++ b/src/test/java/org/boostscale/velox4j/plan/PlanNodeToStringTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.plan;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.*;
+
+import org.boostscale.velox4j.Velox4j;
+import org.boostscale.velox4j.expression.CallTypedExpr;
+import org.boostscale.velox4j.expression.ConstantTypedExpr;
+import org.boostscale.velox4j.expression.FieldAccessTypedExpr;
+import org.boostscale.velox4j.join.JoinType;
+import org.boostscale.velox4j.memory.BytesAllocationListener;
+import org.boostscale.velox4j.memory.MemoryManager;
+import org.boostscale.velox4j.serde.SerdeTests;
+import org.boostscale.velox4j.session.Session;
+import org.boostscale.velox4j.test.Velox4jTests;
+import org.boostscale.velox4j.type.BooleanType;
+import org.boostscale.velox4j.type.IntegerType;
+import org.boostscale.velox4j.type.RowType;
+import org.boostscale.velox4j.variant.BooleanValue;
+import org.boostscale.velox4j.variant.IntegerValue;
+
+public class PlanNodeToStringTest {
+  private static BytesAllocationListener allocationListener;
+  private static MemoryManager memoryManager;
+  private Session session;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Velox4jTests.ensureInitialized();
+    allocationListener = new BytesAllocationListener();
+    memoryManager = Velox4j.newMemoryManager(allocationListener);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    memoryManager.close();
+    Assert.assertEquals(0, allocationListener.currentBytes());
+  }
+
+  @Before
+  public void setUp() {
+    session = Velox4j.newSession(memoryManager);
+  }
+
+  @After
+  public void tearDown() {
+    session.close();
+  }
+
+  @Test
+  public void testTableScanNodeSimple() {
+    PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
+    String result = scan.toFormatString(session, false, false);
+    Assert.assertNotNull(result);
+    Assert.assertTrue("Got: " + result, result.contains("scan-1"));
+  }
+
+  @Test
+  public void testTableScanNodeDetailed() {
+    PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
+    String result = scan.toFormatString(session, true, false);
+    Assert.assertNotNull(result);
+    Assert.assertTrue("Got: " + result, result.contains("scan-1"));
+    // Detailed mode includes output type info
+    Assert.assertTrue("Got: " + result, result.contains("->"));
+  }
+
+  @Test
+  public void testFilterNodeRecursive() {
+    PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
+    FilterNode filter =
+        new FilterNode(
+            "filter-1",
+            ImmutableList.of(scan),
+            ConstantTypedExpr.create(new BooleanType(), new BooleanValue(true)));
+    String result = filter.toFormatString(session, true, true);
+    Assert.assertNotNull(result);
+    // Recursive: should contain both nodes
+    Assert.assertTrue("Should contain filter-1, got: " + result, result.contains("filter-1"));
+    Assert.assertTrue("Should contain scan-1, got: " + result, result.contains("scan-1"));
+    // Recursive output has child indented under parent
+    Assert.assertTrue("Should have indentation, got: " + result, result.contains("  --"));
+  }
+
+  @Test
+  public void testProjectNodeDetailed() {
+    PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
+    ProjectNode project =
+        new ProjectNode(
+            "proj-1",
+            ImmutableList.of(scan),
+            ImmutableList.of("result"),
+            ImmutableList.of(
+                new CallTypedExpr(
+                    new IntegerType(),
+                    ImmutableList.of(
+                        FieldAccessTypedExpr.create(new IntegerType(), "foo"),
+                        ConstantTypedExpr.create(new IntegerType(), new IntegerValue(2))),
+                    "multiply")));
+    String result = project.toFormatString(session, true, true);
+    Assert.assertNotNull(result);
+    Assert.assertTrue("Should contain proj-1, got: " + result, result.contains("proj-1"));
+    Assert.assertTrue("Should contain multiply, got: " + result, result.contains("multiply"));
+  }
+
+  @Test
+  public void testHashJoinNodeDetailed() {
+    RowType leftType =
+        new RowType(
+            ImmutableList.of("l_id", "l_value"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
+    RowType rightType =
+        new RowType(
+            ImmutableList.of("r_id", "r_score"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
+    RowType outputType =
+        new RowType(
+            ImmutableList.of("l_id", "l_value", "r_id", "r_score"),
+            ImmutableList.of(
+                new IntegerType(), new IntegerType(), new IntegerType(), new IntegerType()));
+
+    PlanNode leftScan = SerdeTests.newSampleTableScanNode("left-scan", leftType);
+    PlanNode rightScan = SerdeTests.newSampleTableScanNode("right-scan", rightType);
+
+    HashJoinNode join =
+        new HashJoinNode(
+            "join-1",
+            JoinType.INNER,
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "l_id")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "r_id")),
+            null,
+            leftScan,
+            rightScan,
+            outputType,
+            false,
+            false);
+
+    String result = join.toFormatString(session, true, true);
+    Assert.assertNotNull(result);
+    Assert.assertTrue("Should contain INNER, got: " + result, result.contains("INNER"));
+    Assert.assertTrue("Should contain left-scan, got: " + result, result.contains("left-scan"));
+    Assert.assertTrue("Should contain right-scan, got: " + result, result.contains("right-scan"));
+  }
+}


### PR DESCRIPTION
Expose Velox C++'s `PlanNode::toString(detailed, recursive)` to Java via JNI, enabling human-readable plan tree output for debugging. Using JNI instead of implementing a pure Java `PlanNode.toString` is because this guarantees format consistency with C++ native `PlanNode::toString(detailed, recursive)`

#### Usage
  ```java
  String tree = planNode.toFormatString(session, true, true);
  // -- Filter[filter-1][expression: ...] -> foo:INTEGER, bar:INTEGER
  //   -- TableScan[scan-1][table: ...] -> foo:INTEGER, bar:INTEGER