### PR TITLE
Remove session dependency from PlanNode.toFormatString()

### DIFF
--- a/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/StaticJniWrapper.cc
@@ -264,15 +264,13 @@ selectivityVectorIsValid(JNIEnv* env, jobject javaThis, jlong svId, jint idx) {
 jstring planNodeToString(
     JNIEnv* env,
     jobject javaThis,
-    jlong id,
+    jstring planNodeJson,
     jboolean detailed,
     jboolean recursive) {
   JNI_METHOD_START
-  auto iSerializable = ObjectStore::retrieve<ISerializable>(id);
-  auto planNode =
-      std::dynamic_pointer_cast<const core::PlanNode>(iSerializable);
-  VELOX_CHECK_NOT_NULL(
-      planNode, "Object is not a PlanNode: {}", typeid(*iSerializable).name());
+  spotify::jni::JavaString jJson{env, planNodeJson};
+  auto dynamic = folly::parseJson(jJson.get());
+  auto planNode = ISerializable::deserialize<core::PlanNode>(dynamic);
   auto str = planNode->toString(detailed, recursive);
   return env->NewStringUTF(str.data());
   JNI_METHOD_END(nullptr)
@@ -454,7 +452,7 @@ void StaticJniWrapper::initialize(JNIEnv* env) {
       "planNodeToString",
       (void*)planNodeToString,
       kTypeString,
-      kTypeLong,
+      kTypeString,
       kTypeBool,
       kTypeBool,
       nullptr);

--- a/src/main/java/org/boostscale/velox4j/jni/StaticJniApi.java
+++ b/src/main/java/org/boostscale/velox4j/jni/StaticJniApi.java
@@ -28,6 +28,7 @@ import org.boostscale.velox4j.data.VectorEncoding;
 import org.boostscale.velox4j.iterator.UpIterator;
 import org.boostscale.velox4j.memory.AllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
+import org.boostscale.velox4j.plan.PlanNode;
 import org.boostscale.velox4j.query.SerialTask;
 import org.boostscale.velox4j.query.SerialTaskStats;
 import org.boostscale.velox4j.serde.Serde;
@@ -152,8 +153,8 @@ public class StaticJniApi {
     return type;
   }
 
-  public String planNodeToString(CppObject planNodeCo, boolean detailed, boolean recursive) {
-    return jni.planNodeToString(planNodeCo.id(), detailed, recursive);
+  public String planNodeToString(PlanNode planNode, boolean detailed, boolean recursive) {
+    return jni.planNodeToString(Serde.toPrettyJson(planNode), detailed, recursive);
   }
 
   public ISerializable iSerializableAsJava(ISerializableCo co) {

--- a/src/main/java/org/boostscale/velox4j/jni/StaticJniWrapper.java
+++ b/src/main/java/org/boostscale/velox4j/jni/StaticJniWrapper.java
@@ -85,7 +85,7 @@ public class StaticJniWrapper {
   native String tableWriteTraitsOutputType();
 
   // For PlanNode.
-  native String planNodeToString(long id, boolean detailed, boolean recursive);
+  native String planNodeToString(String planNodeJson, boolean detailed, boolean recursive);
 
   // For serde.
   native String iSerializableAsJava(long id);

--- a/src/main/java/org/boostscale/velox4j/plan/PlanNode.java
+++ b/src/main/java/org/boostscale/velox4j/plan/PlanNode.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import org.boostscale.velox4j.jni.StaticJniApi;
 import org.boostscale.velox4j.serializable.ISerializable;
-import org.boostscale.velox4j.serializable.ISerializableCo;
-import org.boostscale.velox4j.session.Session;
 
 public abstract class PlanNode extends ISerializable {
   private final String id;
@@ -41,14 +39,12 @@ public abstract class PlanNode extends ISerializable {
 
   /**
    * Returns a human-readable string representation of this plan tree using Velox's C++ formatting.
+   * Does not require a session.
    *
-   * @param session the session used to send the plan to C++ for formatting
    * @param detailed if true, includes node-specific details (expressions, join keys, etc.)
    * @param recursive if true, includes the entire subtree; otherwise just this node
    */
-  public String toFormatString(Session session, boolean detailed, boolean recursive) {
-    try (ISerializableCo co = session.iSerializableOps().asCpp(this)) {
-      return StaticJniApi.get().planNodeToString(co, detailed, recursive);
-    }
+  public String toFormatString(boolean detailed, boolean recursive) {
+    return StaticJniApi.get().planNodeToString(this, detailed, recursive);
   }
 }

--- a/src/test/java/org/boostscale/velox4j/plan/PlanNodeToStringTest.java
+++ b/src/test/java/org/boostscale/velox4j/plan/PlanNodeToStringTest.java
@@ -16,66 +16,48 @@ package org.boostscale.velox4j.plan;
 import com.google.common.collect.ImmutableList;
 import org.junit.*;
 
-import org.boostscale.velox4j.Velox4j;
 import org.boostscale.velox4j.expression.CallTypedExpr;
+import org.boostscale.velox4j.expression.CastTypedExpr;
 import org.boostscale.velox4j.expression.ConstantTypedExpr;
 import org.boostscale.velox4j.expression.FieldAccessTypedExpr;
 import org.boostscale.velox4j.join.JoinType;
-import org.boostscale.velox4j.memory.BytesAllocationListener;
-import org.boostscale.velox4j.memory.MemoryManager;
 import org.boostscale.velox4j.serde.SerdeTests;
-import org.boostscale.velox4j.session.Session;
 import org.boostscale.velox4j.test.Velox4jTests;
+import org.boostscale.velox4j.type.BigIntType;
 import org.boostscale.velox4j.type.BooleanType;
 import org.boostscale.velox4j.type.IntegerType;
 import org.boostscale.velox4j.type.RowType;
+import org.boostscale.velox4j.type.VarCharType;
 import org.boostscale.velox4j.variant.BooleanValue;
 import org.boostscale.velox4j.variant.IntegerValue;
 
 public class PlanNodeToStringTest {
-  private static BytesAllocationListener allocationListener;
-  private static MemoryManager memoryManager;
-  private Session session;
+
+  private static final String SAMPLE_SCAN_DETAILS =
+      "table: tab-1,"
+          + " range filters: [(complex_type[1].id,"
+          + " Filter(AlwaysTrue, deterministic, with nulls))],"
+          + " remaining filter: (always_true()),"
+          + " data columns: ROW<foo:INTEGER,bar:INTEGER>,"
+          + " table parameters: [tk:tv]";
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Velox4jTests.ensureInitialized();
-    allocationListener = new BytesAllocationListener();
-    memoryManager = Velox4j.newMemoryManager(allocationListener);
-  }
-
-  @AfterClass
-  public static void afterClass() throws Exception {
-    memoryManager.close();
-    Assert.assertEquals(0, allocationListener.currentBytes());
-  }
-
-  @Before
-  public void setUp() {
-    session = Velox4j.newSession(memoryManager);
-  }
-
-  @After
-  public void tearDown() {
-    session.close();
   }
 
   @Test
   public void testTableScanNodeSimple() {
     PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
-    String result = scan.toFormatString(session, false, false);
-    Assert.assertNotNull(result);
-    Assert.assertTrue("Got: " + result, result.contains("scan-1"));
+    Assert.assertEquals("-- TableScan[scan-1]\n", scan.toFormatString(false, false));
   }
 
   @Test
   public void testTableScanNodeDetailed() {
     PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
-    String result = scan.toFormatString(session, true, false);
-    Assert.assertNotNull(result);
-    Assert.assertTrue("Got: " + result, result.contains("scan-1"));
-    // Detailed mode includes output type info
-    Assert.assertTrue("Got: " + result, result.contains("->"));
+    Assert.assertEquals(
+        "-- TableScan[scan-1][" + SAMPLE_SCAN_DETAILS + "] -> foo:INTEGER, bar:INTEGER\n",
+        scan.toFormatString(true, false));
   }
 
   @Test
@@ -86,13 +68,12 @@ public class PlanNodeToStringTest {
             "filter-1",
             ImmutableList.of(scan),
             ConstantTypedExpr.create(new BooleanType(), new BooleanValue(true)));
-    String result = filter.toFormatString(session, true, true);
-    Assert.assertNotNull(result);
-    // Recursive: should contain both nodes
-    Assert.assertTrue("Should contain filter-1, got: " + result, result.contains("filter-1"));
-    Assert.assertTrue("Should contain scan-1, got: " + result, result.contains("scan-1"));
-    // Recursive output has child indented under parent
-    Assert.assertTrue("Should have indentation, got: " + result, result.contains("  --"));
+    Assert.assertEquals(
+        "-- Filter[filter-1][expression: true] -> foo:INTEGER, bar:INTEGER\n"
+            + "  -- TableScan[scan-1]["
+            + SAMPLE_SCAN_DETAILS
+            + "] -> foo:INTEGER, bar:INTEGER\n",
+        filter.toFormatString(true, true));
   }
 
   @Test
@@ -110,10 +91,12 @@ public class PlanNodeToStringTest {
                         FieldAccessTypedExpr.create(new IntegerType(), "foo"),
                         ConstantTypedExpr.create(new IntegerType(), new IntegerValue(2))),
                     "multiply")));
-    String result = project.toFormatString(session, true, true);
-    Assert.assertNotNull(result);
-    Assert.assertTrue("Should contain proj-1, got: " + result, result.contains("proj-1"));
-    Assert.assertTrue("Should contain multiply, got: " + result, result.contains("multiply"));
+    Assert.assertEquals(
+        "-- Project[proj-1][expressions: (result:INTEGER, multiply(\"foo\",2))] -> result:INTEGER\n"
+            + "  -- TableScan[scan-1]["
+            + SAMPLE_SCAN_DETAILS
+            + "] -> foo:INTEGER, bar:INTEGER\n",
+        project.toFormatString(true, true));
   }
 
   @Test
@@ -135,6 +118,21 @@ public class PlanNodeToStringTest {
     PlanNode leftScan = SerdeTests.newSampleTableScanNode("left-scan", leftType);
     PlanNode rightScan = SerdeTests.newSampleTableScanNode("right-scan", rightType);
 
+    String leftScanDetails =
+        "table: tab-1,"
+            + " range filters: [(complex_type[1].id,"
+            + " Filter(AlwaysTrue, deterministic, with nulls))],"
+            + " remaining filter: (always_true()),"
+            + " data columns: ROW<l_id:INTEGER,l_value:INTEGER>,"
+            + " table parameters: [tk:tv]";
+    String rightScanDetails =
+        "table: tab-1,"
+            + " range filters: [(complex_type[1].id,"
+            + " Filter(AlwaysTrue, deterministic, with nulls))],"
+            + " remaining filter: (always_true()),"
+            + " data columns: ROW<r_id:INTEGER,r_score:INTEGER>,"
+            + " table parameters: [tk:tv]";
+
     HashJoinNode join =
         new HashJoinNode(
             "join-1",
@@ -148,10 +146,124 @@ public class PlanNodeToStringTest {
             false,
             false);
 
-    String result = join.toFormatString(session, true, true);
-    Assert.assertNotNull(result);
-    Assert.assertTrue("Should contain INNER, got: " + result, result.contains("INNER"));
-    Assert.assertTrue("Should contain left-scan, got: " + result, result.contains("left-scan"));
-    Assert.assertTrue("Should contain right-scan, got: " + result, result.contains("right-scan"));
+    Assert.assertEquals(
+        "-- HashJoin[join-1][INNER l_id=r_id]"
+            + " -> l_id:INTEGER, l_value:INTEGER, r_id:INTEGER, r_score:INTEGER\n"
+            + "  -- TableScan[left-scan]["
+            + leftScanDetails
+            + "] -> l_id:INTEGER, l_value:INTEGER\n"
+            + "  -- TableScan[right-scan]["
+            + rightScanDetails
+            + "] -> r_id:INTEGER, r_score:INTEGER\n",
+        join.toFormatString(true, true));
+  }
+
+  @Test
+  public void testFilterWithComplexExpression() {
+    // WHERE age >= 18 AND length(name) > 0
+    PlanNode scan =
+        SerdeTests.newSampleTableScanNode(
+            "scan-1",
+            new RowType(
+                ImmutableList.of("age", "name"),
+                ImmutableList.of(new IntegerType(), new VarCharType())));
+
+    CallTypedExpr ageCheck =
+        new CallTypedExpr(
+            new BooleanType(),
+            ImmutableList.of(
+                FieldAccessTypedExpr.create(new IntegerType(), "age"),
+                ConstantTypedExpr.create(new IntegerType(), new IntegerValue(18))),
+            "gte");
+    CallTypedExpr lengthCheck =
+        new CallTypedExpr(
+            new BooleanType(),
+            ImmutableList.of(
+                new CallTypedExpr(
+                    new IntegerType(),
+                    ImmutableList.of(FieldAccessTypedExpr.create(new VarCharType(), "name")),
+                    "length"),
+                ConstantTypedExpr.create(new IntegerType(), new IntegerValue(0))),
+            "gt");
+    CallTypedExpr andExpr =
+        new CallTypedExpr(new BooleanType(), ImmutableList.of(ageCheck, lengthCheck), "and");
+
+    FilterNode filter = new FilterNode("filter-1", ImmutableList.of(scan), andExpr);
+    Assert.assertEquals(
+        "-- Filter[filter-1][expression: and(gte(\"age\",18),gt(length(\"name\"),0))]"
+            + " -> age:INTEGER, name:VARCHAR\n",
+        filter.toFormatString(true, false));
+  }
+
+  @Test
+  public void testProjectWithCastExpression() {
+    // SELECT CAST(foo AS BIGINT) AS foo_big, CAST(bar AS VARCHAR) AS bar_str
+    PlanNode scan = SerdeTests.newSampleTableScanNode("scan-1", SerdeTests.newSampleOutputType());
+    ProjectNode project =
+        new ProjectNode(
+            "proj-1",
+            ImmutableList.of(scan),
+            ImmutableList.of("foo_big", "bar_str"),
+            ImmutableList.of(
+                CastTypedExpr.create(
+                    new BigIntType(), FieldAccessTypedExpr.create(new IntegerType(), "foo"), false),
+                CastTypedExpr.create(
+                    new VarCharType(),
+                    FieldAccessTypedExpr.create(new IntegerType(), "bar"),
+                    true)));
+
+    Assert.assertEquals(
+        "-- Project[proj-1][expressions:"
+            + " (foo_big:BIGINT, cast(\"foo\" as BIGINT)),"
+            + " (bar_str:VARCHAR, try_cast(\"bar\" as VARCHAR))]"
+            + " -> foo_big:BIGINT, bar_str:VARCHAR\n",
+        project.toFormatString(true, false));
+  }
+
+  @Test
+  public void testHashJoinWithPostFilter() {
+    RowType leftType =
+        new RowType(
+            ImmutableList.of("l_id", "l_val"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
+    RowType rightType =
+        new RowType(
+            ImmutableList.of("r_id", "r_val"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
+    RowType outputType =
+        new RowType(
+            ImmutableList.of("l_id", "l_val", "r_id", "r_val"),
+            ImmutableList.of(
+                new IntegerType(), new IntegerType(), new IntegerType(), new IntegerType()));
+
+    PlanNode leftScan = SerdeTests.newSampleTableScanNode("left-scan", leftType);
+    PlanNode rightScan = SerdeTests.newSampleTableScanNode("right-scan", rightType);
+
+    // Post-join filter: l_val > r_val
+    CallTypedExpr postFilter =
+        new CallTypedExpr(
+            new BooleanType(),
+            ImmutableList.of(
+                FieldAccessTypedExpr.create(new IntegerType(), "l_val"),
+                FieldAccessTypedExpr.create(new IntegerType(), "r_val")),
+            "gt");
+
+    HashJoinNode join =
+        new HashJoinNode(
+            "join-1",
+            JoinType.LEFT,
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "l_id")),
+            ImmutableList.of(FieldAccessTypedExpr.create(new IntegerType(), "r_id")),
+            postFilter,
+            leftScan,
+            rightScan,
+            outputType,
+            false,
+            false);
+
+    Assert.assertEquals(
+        "-- HashJoin[join-1][LEFT l_id=r_id, filter: gt(\"l_val\",\"r_val\")]"
+            + " -> l_id:INTEGER, l_val:INTEGER, r_id:INTEGER, r_val:INTEGER\n",
+        join.toFormatString(true, false));
   }
 }


### PR DESCRIPTION
Follow-up of https://github.com/boostscale/velox4j/pull/611, this PR changes `planNodeToString` JNI method to accept the plan as a JSON string instead of a C++ object handle and removes the session  requirement from `PlanNode.toFormatString()`.

#### Before
```java
// Requires a session to send the plan to C++ first
String tree = planNode.toFormatString(session, true, true);
// Internally: Java plan → asCpp() (needs session) → C++ handle → planNodeToString(handle) → string
```
#### After
```java
// No session needed
String tree = planNode.toFormatString(true, true);
// Internally: Java plan → Serde.toJson() → JSON string via JNI → C++ deserializes → toString() → string
```