### PR TITLE
Improve test coverage for LocalPartition 

### DIFF
--- a/src/main/java/org/boostscale/velox4j/data/BaseVector.java
+++ b/src/main/java/org/boostscale/velox4j/data/BaseVector.java
@@ -81,7 +81,7 @@ public class BaseVector implements CppObject {
     return BaseVectors.serializeOne(this);
   }
 
-  public String toString(BufferAllocator alloc) {
+  protected String toString(BufferAllocator alloc) {
     try (final FieldVector fv = Arrow.toArrowVector(alloc, this)) {
       return fv.toString();
     }

--- a/src/main/java/org/boostscale/velox4j/data/RowVector.java
+++ b/src/main/java/org/boostscale/velox4j/data/RowVector.java
@@ -25,7 +25,7 @@ public class RowVector extends BaseVector {
   }
 
   @Override
-  public String toString(BufferAllocator alloc) {
+  protected String toString(BufferAllocator alloc) {
     try (final VectorSchemaRoot vsr = Arrow.toArrowVectorSchemaRoot(alloc, this)) {
       return vsr.contentToTSVString();
     }

--- a/src/main/java/org/boostscale/velox4j/plan/partition/HashPartitionFunctionSpec.java
+++ b/src/main/java/org/boostscale/velox4j/plan/partition/HashPartitionFunctionSpec.java
@@ -39,7 +39,7 @@ public class HashPartitionFunctionSpec extends PartitionFunctionSpec {
       @JsonProperty("constants") List<ConstantTypedExpr> constants) {
     this.inputType = inputType;
     this.keyChannels = keyChannels;
-    this.constants = constants != null ? constants : Collections.emptyList();
+    this.constants = constants;
   }
 
   public HashPartitionFunctionSpec(RowType inputType, List<Integer> keyChannels) {

--- a/src/test/java/org/boostscale/velox4j/query/QueryTest.java
+++ b/src/test/java/org/boostscale/velox4j/query/QueryTest.java
@@ -16,6 +16,7 @@ package org.boostscale.velox4j.query;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -818,12 +819,10 @@ public class QueryTest {
     task.noMoreSplits(scanNode2.getId());
 
     UpIteratorTests.assertIterator(task)
-            .assertNumRowVectors(2)
-            .assertRowVectorToString(
-                    0, ResourceTests.readResourceAsString("query-output/tpch-table-scan-nation.tsv"))
-            .assertRowVectorToString(
-                    1, ResourceTests.readResourceAsString("query-output/tpch-table-scan-nation.tsv"))
-            .run();
+        .assertNumRowVectors(2)
+        .assertRowVectorsToString(
+            ResourceTests.readResourceAsString("query-output/tpch-local-partition-gather-1.tsv"))
+        .run();
   }
 
   @Test
@@ -1038,5 +1037,24 @@ public class QueryTest {
             null,
             ImmutableList.of());
     return aggregationNode;
+  }
+
+  private static String tsvHeader(String tsv) {
+    final String[] lines = tsvLines(tsv);
+    Assert.assertTrue(lines.length > 0);
+    return lines[0];
+  }
+
+  private static List<String> sortedTsvRows(String tsv) {
+    final String[] lines = tsvLines(tsv);
+    return Arrays.stream(lines).skip(1).sorted().collect(Collectors.toList());
+  }
+
+  private static String[] tsvLines(String tsv) {
+    String normalized = tsv;
+    while (normalized.endsWith("\n")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized.split("\n");
   }
 }

--- a/src/test/java/org/boostscale/velox4j/query/QueryTest.java
+++ b/src/test/java/org/boostscale/velox4j/query/QueryTest.java
@@ -45,6 +45,7 @@ import org.boostscale.velox4j.join.JoinType;
 import org.boostscale.velox4j.memory.BytesAllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
 import org.boostscale.velox4j.plan.*;
+import org.boostscale.velox4j.plan.partition.GatherPartitionFunctionSpec;
 import org.boostscale.velox4j.serde.Serde;
 import org.boostscale.velox4j.session.Session;
 import org.boostscale.velox4j.sort.SortOrder;
@@ -792,6 +793,37 @@ public class QueryTest {
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-limit-1.tsv"))
         .run();
+  }
+
+  @Test
+  public void testLocalPartitionGather() {
+    final File file = NATION_FILE.file();
+    final RowType outputType = NATION_FILE.schema();
+    final TableScanNode scanNode1 = newSampleTableScanNode("id-1", outputType);
+    final TableScanNode scanNode2 = newSampleTableScanNode("id-2", outputType);
+    final ConnectorSplit split1 = newSampleSplit(file);
+    final ConnectorSplit split2 = newSampleSplit(file);
+    final LocalPartitionNode localPartitionNode =
+        new LocalPartitionNode(
+            "id-3",
+            LocalPartitionNode.Type.GATHER,
+            false,
+            new GatherPartitionFunctionSpec(),
+            ImmutableList.of(scanNode1, scanNode2));
+    final Query query = new Query(localPartitionNode, Config.empty(), ConnectorConfig.empty());
+    final SerialTask task = session.queryOps().execute(query);
+    task.addSplit(scanNode1.getId(), split1);
+    task.noMoreSplits(scanNode1.getId());
+    task.addSplit(scanNode2.getId(), split2);
+    task.noMoreSplits(scanNode2.getId());
+
+    UpIteratorTests.assertIterator(task)
+            .assertNumRowVectors(2)
+            .assertRowVectorToString(
+                    0, ResourceTests.readResourceAsString("query-output/tpch-table-scan-nation.tsv"))
+            .assertRowVectorToString(
+                    1, ResourceTests.readResourceAsString("query-output/tpch-table-scan-nation.tsv"))
+            .run();
   }
 
   @Test

--- a/src/test/java/org/boostscale/velox4j/serde/PartitionFunctionSpecTest.java
+++ b/src/test/java/org/boostscale/velox4j/serde/PartitionFunctionSpecTest.java
@@ -40,8 +40,7 @@ public class PartitionFunctionSpecTest {
   public void testHashPartitionFunctionSpec() {
     final RowType inputType =
         new RowType(
-            ImmutableList.of("foo", "bar"),
-            ImmutableList.of(new IntegerType(), new IntegerType()));
+            ImmutableList.of("foo", "bar"), ImmutableList.of(new IntegerType(), new IntegerType()));
     SerdeTests.testISerializableRoundTrip(
         new HashPartitionFunctionSpec(inputType, ImmutableList.of(0)));
   }

--- a/src/test/java/org/boostscale/velox4j/serde/PartitionFunctionSpecTest.java
+++ b/src/test/java/org/boostscale/velox4j/serde/PartitionFunctionSpecTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.boostscale.velox4j.serde;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.boostscale.velox4j.plan.partition.GatherPartitionFunctionSpec;
+import org.boostscale.velox4j.plan.partition.HashPartitionFunctionSpec;
+import org.boostscale.velox4j.plan.partition.RoundRobinPartitionFunctionSpec;
+import org.boostscale.velox4j.test.Velox4jTests;
+import org.boostscale.velox4j.type.IntegerType;
+import org.boostscale.velox4j.type.RowType;
+
+public class PartitionFunctionSpecTest {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Velox4jTests.ensureInitialized();
+  }
+
+  @Test
+  public void testGatherPartitionFunctionSpec() {
+    SerdeTests.testISerializableRoundTrip(new GatherPartitionFunctionSpec());
+  }
+
+  @Test
+  public void testHashPartitionFunctionSpec() {
+    final RowType inputType =
+        new RowType(
+            ImmutableList.of("foo", "bar"),
+            ImmutableList.of(new IntegerType(), new IntegerType()));
+    SerdeTests.testISerializableRoundTrip(
+        new HashPartitionFunctionSpec(inputType, ImmutableList.of(0)));
+  }
+
+  @Test
+  public void testRoundRobinPartitionFunctionSpec() {
+    SerdeTests.testISerializableRoundTrip(new RoundRobinPartitionFunctionSpec());
+  }
+}

--- a/src/test/java/org/boostscale/velox4j/test/UpIteratorTests.java
+++ b/src/test/java/org/boostscale/velox4j/test/UpIteratorTests.java
@@ -23,6 +23,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.junit.Assert;
 
 import org.boostscale.velox4j.collection.Streams;
+import org.boostscale.velox4j.data.BaseVectors;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.iterator.CloseableIterator;
 import org.boostscale.velox4j.iterator.UpIterator;
@@ -81,7 +82,7 @@ public final class UpIteratorTests {
           new Consumer<RowVector>() {
             @Override
             public void accept(RowVector vector) {
-              Assert.assertEquals(expected, vector.toString(alloc));
+              Assert.assertEquals(expected, vector.toString());
             }
           });
     }
@@ -105,6 +106,35 @@ public final class UpIteratorTests {
               if (argument.i == i) {
                 body.accept(argument.rv);
               }
+            }
+          });
+      return this;
+    }
+
+    public IteratorAssertionBuilder assertRowVectorsToString(String expected) {
+      return assertRowVectors(
+          new Consumer<List<RowVector>>() {
+            @Override
+            public void accept(List<RowVector> rowVectors) {
+              Assert.assertEquals(expected, BaseVectors.toString(rowVectors));
+            }
+          });
+    }
+
+    public IteratorAssertionBuilder assertRowVectors(Consumer<List<RowVector>> body) {
+      final List<RowVector> rowVectors = new ArrayList<>();
+      assertForEach(
+          new Consumer<Argument>() {
+            @Override
+            public void accept(Argument argument) {
+              rowVectors.add(argument.rv);
+            }
+          });
+      assertFinal(
+          new Runnable() {
+            @Override
+            public void run() {
+              body.accept(rowVectors);
             }
           });
       return this;

--- a/src/test/resources/query-output/tpch-local-partition-gather-1.tsv
+++ b/src/test/resources/query-output/tpch-local-partition-gather-1.tsv
@@ -1,0 +1,56 @@
+Vector #0
+n_nationkey	n_name	n_regionkey	n_comment
+0	ALGERIA	0	haggle. carefully final deposits detect slyly agai
+1	ARGENTINA	1	al foxes promise slyly according to the regular accounts. bold requests alon
+2	BRAZIL	1	y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special
+3	CANADA	1	eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
+4	EGYPT	4	y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
+5	ETHIOPIA	0	ven packages wake quickly. regu
+6	FRANCE	3	refully final requests. regular, ironi
+7	GERMANY	3	l platelets. regular accounts x-ray: unusual, regular acco
+8	INDIA	2	ss excuses cajole slyly across the packages. deposits print aroun
+9	INDONESIA	2	slyly express asymptotes. regular deposits haggle slyly. carefully ironic hockey players sleep blithely. carefull
+10	IRAN	4	efully alongside of the slyly final dependencies.
+11	IRAQ	4	nic deposits boost atop the quickly final requests? quickly regula
+12	JAPAN	2	ously. final, express gifts cajole a
+13	JORDAN	4	ic deposits are blithely about the carefully regular pa
+14	KENYA	0	pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t
+15	MOROCCO	0	rns. blithely bold courts among the closely regular packages use furiously bold platelets?
+16	MOZAMBIQUE	0	s. ironic, unusual asymptotes wake blithely r
+17	PERU	1	platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun
+18	CHINA	2	c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos
+19	ROMANIA	3	ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account
+20	SAUDI ARABIA	4	ts. silent requests haggle. closely express packages sleep across the blithely
+21	VIETNAM	2	hely enticingly express accounts. even, final
+22	RUSSIA	3	requests against the platelets use never according to the quickly regular pint
+23	UNITED KINGDOM	3	eans boost carefully special requests. accounts are. carefull
+24	UNITED STATES	1	y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+
+Vector #1
+n_nationkey	n_name	n_regionkey	n_comment
+0	ALGERIA	0	haggle. carefully final deposits detect slyly agai
+1	ARGENTINA	1	al foxes promise slyly according to the regular accounts. bold requests alon
+2	BRAZIL	1	y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special
+3	CANADA	1	eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold
+4	EGYPT	4	y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d
+5	ETHIOPIA	0	ven packages wake quickly. regu
+6	FRANCE	3	refully final requests. regular, ironi
+7	GERMANY	3	l platelets. regular accounts x-ray: unusual, regular acco
+8	INDIA	2	ss excuses cajole slyly across the packages. deposits print aroun
+9	INDONESIA	2	slyly express asymptotes. regular deposits haggle slyly. carefully ironic hockey players sleep blithely. carefull
+10	IRAN	4	efully alongside of the slyly final dependencies.
+11	IRAQ	4	nic deposits boost atop the quickly final requests? quickly regula
+12	JAPAN	2	ously. final, express gifts cajole a
+13	JORDAN	4	ic deposits are blithely about the carefully regular pa
+14	KENYA	0	pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t
+15	MOROCCO	0	rns. blithely bold courts among the closely regular packages use furiously bold platelets?
+16	MOZAMBIQUE	0	s. ironic, unusual asymptotes wake blithely r
+17	PERU	1	platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun
+18	CHINA	2	c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos
+19	ROMANIA	3	ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account
+20	SAUDI ARABIA	4	ts. silent requests haggle. closely express packages sleep across the blithely
+21	VIETNAM	2	hely enticingly express accounts. even, final
+22	RUSSIA	3	requests against the platelets use never according to the quickly regular pint
+23	UNITED KINGDOM	3	eans boost carefully special requests. accounts are. carefull
+24	UNITED STATES	1	y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+


### PR DESCRIPTION
As title. The PR modifies test code to improve test coverage for LocalPartition.

A test case for LocalPartition + gather is added.

LocalPartition + Hash / RoundRobin are only effective under parallel execution mode, so we don't need to test them.