### PR TITLE
Set default Java version in setup-al2023.sh instead of in ut-java.yml

### DIFF
--- a/.github/workflows/scripts/common/setup-al2023.sh
+++ b/.github/workflows/scripts/common/setup-al2023.sh
@@ -59,7 +59,10 @@ ldconfig
 # Both the full (non-headless) package and the devel package are needed.
 # The full package provides libjawt.so required by CMake's FindJNI.
 dnf -y install java-21-amazon-corretto java-21-amazon-corretto-devel
-export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
+alternatives --set java /usr/lib/jvm/java-21-amazon-corretto.x86_64/bin/java
+alternatives --set javac /usr/lib/jvm/java-21-amazon-corretto.x86_64/bin/javac
+java -version
+javac -version
 
 # Install Maven.
 if [ -z "$(which mvn 2>/dev/null)" ]; then

--- a/.github/workflows/ut-java.yml
+++ b/.github/workflows/ut-java.yml
@@ -109,7 +109,6 @@ jobs:
           docker exec al2023-container bash -c "
             export CCACHE_DIR=/velox4j/${{ env.CACHE_DIR }}
             export CCACHE_MAXSIZE=3000M
-            export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
             bash .github/workflows/scripts/common/setup-al2023.sh
             mvn clean generate-resources
           "
@@ -119,7 +118,6 @@ jobs:
       - name: Run UTs
         run: |
           docker exec al2023-container bash -c "
-            export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
             mvn clean test -Dskip.cpp.build
           "
       - name: Stop Docker container

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ A setup script is provided to install all required dependencies on AL2023:
 # 1. Run the setup script (as root or with sudo).
 sudo bash .github/workflows/scripts/common/setup-al2023.sh
 
-# 2. Set JAVA_HOME and build.
-export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
+# 2. Build.
 mvn clean install -DskipTests
 ```
 
@@ -152,7 +151,6 @@ Alternatively, use Docker from any Linux machine:
 docker run --init -it -v $(pwd):/velox4j -w /velox4j amazonlinux:2023 bash
 
 # Inside the container:
-export JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto.x86_64
 bash .github/workflows/scripts/common/setup-al2023.sh
 mvn clean install -DskipTests
 ```


### PR DESCRIPTION
As title. An attempt to set default Java in `setup-al2023.sh`, so `ut-java.yml` can be made simpler.