### PR TITLE
Improve `~SerialTask` against asynchronous leakages

### DIFF
--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -74,15 +74,14 @@ SerialTask::SerialTask(
 }
 
 SerialTask::~SerialTask() {
-  if (task_ != nullptr) {
-    if (task_->isRunning()) {
-      // calling .wait() may take no effect in single thread execution mode.
-      task_->requestCancel().wait();
-    }
-    auto deletionFuture = task_->taskDeletionFuture();
-    task_.reset();
-    deletionFuture.wait();
+  VELOX_CHECK_NOT_NULL(task_);
+  if (task_->isRunning()) {
+    // calling .wait() may take no effect in single thread execution mode.
+    task_->requestCancel().wait();
   }
+  auto deletionFuture = task_->taskDeletionFuture();
+  task_.reset();
+  deletionFuture.wait();
 }
 
 UpIterator::State SerialTask::advance() {

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -74,10 +74,14 @@ SerialTask::SerialTask(
 }
 
 SerialTask::~SerialTask() {
-  if (task_ != nullptr && task_->isRunning()) {
-    // FIXME: Calling .wait() may take no effect in single thread execution
-    //  mode.
-    task_->requestCancel().wait();
+  if (task_ != nullptr) {
+    if (task_->isRunning()) {
+      // calling .wait() may take no effect in single thread execution mode.
+      task_->requestCancel().wait();
+    }
+    auto deletionFuture = task_->taskDeletionFuture();
+    task_.reset();
+    deletionFuture.wait();
   }
 }
 


### PR DESCRIPTION
Velox's task smart pointers may outlive ~SerialTask in some asynchronous execution cases, causing unexpected leakages. The patch adds a protection line to avoid this kind of leak.