### PR TITLE
Rename UpIterator and DownIterator to ExportIterator and ImportIterator respectively, and update related references

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ public static void main(String[] args) {
   task.noMoreSplits(scanNode.getId());
 
   // 8. Create a Java iterator from the Velox task.
-  final Iterator<RowVector> itr = UpIterators.asJavaIterator(task);
+  final Iterator<RowVector> itr = ExportIterators.asJavaIterator(task);
 
   // 9. Collect and print results.
   while (itr.hasNext()) {

--- a/src/main/cpp/main/CMakeLists.txt
+++ b/src/main/cpp/main/CMakeLists.txt
@@ -5,8 +5,8 @@ set(VELOX4J_SOURCES
     velox4j/jni/JniError.cc
     velox4j/jni/JniLoader.cc
     velox4j/jni/JniWrapper.cc
-    velox4j/iterator/UpIterator.cc
-    velox4j/iterator/DownIterator.cc
+    velox4j/iterator/ExportIterator.cc
+    velox4j/iterator/ImportIterator.cc
     velox4j/lifecycle/ObjectStore.cc
     velox4j/lifecycle/Session.cc
     velox4j/arrow/Arrow.cc

--- a/src/main/cpp/main/velox4j/iterator/ExportIterator.cc
+++ b/src/main/cpp/main/velox4j/iterator/ExportIterator.cc
@@ -12,4 +12,4 @@
  * limitations under the License.
  */
 
-#include "velox4j/iterator/UpIterator.h"
+#include "velox4j/iterator/ExportIterator.h"

--- a/src/main/cpp/main/velox4j/iterator/ExportIterator.h
+++ b/src/main/cpp/main/velox4j/iterator/ExportIterator.h
@@ -19,23 +19,23 @@
 
 namespace velox4j {
 
-/// An up-iterator is the opposite of down-iterator. It transmits data
+/// An export-iterator is the opposite of import-iterator. It transmits data
 /// that is output from Velox pipeline from C++ to Java.
-class UpIterator {
+class ExportIterator {
  public:
   enum class State { AVAILABLE = 0, BLOCKED = 1, FINISHED = 2 };
 
   // CTOR.
-  UpIterator() = default;
+  ExportIterator() = default;
 
   // Delete copy/move CTORs.
-  UpIterator(UpIterator&&) = delete;
-  UpIterator(const UpIterator&) = delete;
-  UpIterator& operator=(const UpIterator&) = delete;
-  UpIterator& operator=(UpIterator&&) = delete;
+  ExportIterator(ExportIterator&&) = delete;
+  ExportIterator(const ExportIterator&) = delete;
+  ExportIterator& operator=(const ExportIterator&) = delete;
+  ExportIterator& operator=(ExportIterator&&) = delete;
 
   // DTOR.
-  virtual ~UpIterator() = default;
+  virtual ~ExportIterator() = default;
 
   // Gets the next state.
   virtual State advance() = 0;

--- a/src/main/cpp/main/velox4j/iterator/ImportIterator.cc
+++ b/src/main/cpp/main/velox4j/iterator/ImportIterator.cc
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-#include "velox4j/iterator/DownIterator.h"
+#include "velox4j/iterator/ImportIterator.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/lifecycle/ObjectStore.h"
 
@@ -20,16 +20,16 @@ namespace velox4j {
 using namespace facebook::velox;
 
 namespace {
-const char* kClassName = "org/boostscale/velox4j/iterator/DownIterator";
+const char* kClassName = "org/boostscale/velox4j/iterator/ImportIterator";
 } // namespace
 
-void DownIteratorJniWrapper::mapFields() {}
+void ImportIteratorJniWrapper::mapFields() {}
 
-const char* DownIteratorJniWrapper::getCanonicalName() const {
+const char* ImportIteratorJniWrapper::getCanonicalName() const {
   return kClassName;
 }
 
-void DownIteratorJniWrapper::initialize(JNIEnv* env) {
+void ImportIteratorJniWrapper::initialize(JNIEnv* env) {
   JavaClass::setClass(env);
 
   cacheMethod(env, "advance", kTypeInt, nullptr);
@@ -40,29 +40,29 @@ void DownIteratorJniWrapper::initialize(JNIEnv* env) {
   registerNativeMethods(env);
 }
 
-DownIterator::DownIterator(JNIEnv* env, jobject ref) : ExternalStream() {
+ImportIterator::ImportIterator(JNIEnv* env, jobject ref) : ExternalStream() {
   ref_ = env->NewGlobalRef(ref);
   waitExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(1);
 }
 
-DownIterator::~DownIterator() {
+ImportIterator::~ImportIterator() {
   try {
     close();
     getLocalJNIEnv()->DeleteGlobalRef(ref_);
   } catch (const std::exception& ex) {
     LOG(WARNING) << "Unable to destroy the global reference to the Java side "
-                    "down iterator: "
+                    "import iterator: "
                  << ex.what();
   }
 }
 
-std::optional<RowVectorPtr> DownIterator::read(ContinueFuture& future) {
+std::optional<RowVectorPtr> ImportIterator::read(ContinueFuture& future) {
   VELOX_CHECK(!closed_);
   {
     std::lock_guard l(mutex_);
     VELOX_CHECK(
         promises_.empty(),
-        "DownIterator::read is called while the last read operation is "
+        "ImportIterator::read is called while the last read operation is "
         "awaiting. Aborting.");
   }
   const State state = advance();
@@ -74,7 +74,7 @@ std::optional<RowVectorPtr> DownIterator::read(ContinueFuture& future) {
     }
     case State::BLOCKED: {
       auto [readPromise, readFuture] =
-          makeVeloxContinuePromiseContract(fmt::format("DownIterator::read"));
+          makeVeloxContinuePromiseContract(fmt::format("ImportIterator::read"));
       // Returns a future that is fulfilled immediately to signal Velox
       // that this stream is still open and is currently waiting for input.
       future = std::move(readFuture);
@@ -117,7 +117,7 @@ std::optional<RowVectorPtr> DownIterator::read(ContinueFuture& future) {
   return std::nullopt;
 }
 
-void DownIterator::close() {
+void ImportIterator::close() {
   bool expected = false;
   if (!closed_.compare_exchange_strong(expected, true)) {
     return;
@@ -130,7 +130,7 @@ void DownIterator::close() {
   waitExecutor_->join();
 }
 
-void DownIterator::wait() {
+void ImportIterator::wait() {
   auto* env = getLocalJNIEnv();
   static const auto* clazz = jniClassRegistry()->get(kClassName);
   static jmethodID methodId = clazz->getMethod("waitFor");
@@ -138,7 +138,7 @@ void DownIterator::wait() {
   checkException(env);
 }
 
-DownIterator::State DownIterator::advance() {
+ImportIterator::State ImportIterator::advance() {
   auto* env = getLocalJNIEnv();
   static const auto* clazz = jniClassRegistry()->get(kClassName);
   static jmethodID methodId = clazz->getMethod("advance");
@@ -147,7 +147,7 @@ DownIterator::State DownIterator::advance() {
   return state;
 }
 
-RowVectorPtr DownIterator::get() {
+RowVectorPtr ImportIterator::get() {
   auto* env = getLocalJNIEnv();
   static const auto* clazz = jniClassRegistry()->get(kClassName);
   static jmethodID methodId = clazz->getMethod("get");

--- a/src/main/cpp/main/velox4j/iterator/ImportIterator.h
+++ b/src/main/cpp/main/velox4j/iterator/ImportIterator.h
@@ -20,14 +20,14 @@
 #include "velox4j/connector/ExternalStream.h"
 
 namespace velox4j {
-// JNI wrapper that exposes a down-iterator to Java.
-class DownIteratorJniWrapper final : public spotify::jni::JavaClass {
+// JNI wrapper that exposes an import-iterator to Java.
+class ImportIteratorJniWrapper final : public spotify::jni::JavaClass {
  public:
-  explicit DownIteratorJniWrapper(JNIEnv* env) : JavaClass(env) {
-    DownIteratorJniWrapper::initialize(env);
+  explicit ImportIteratorJniWrapper(JNIEnv* env) : JavaClass(env) {
+    ImportIteratorJniWrapper::initialize(env);
   }
 
-  DownIteratorJniWrapper() : JavaClass() {};
+  ImportIteratorJniWrapper() : JavaClass() {};
 
   const char* getCanonicalName() const override;
 
@@ -36,26 +36,26 @@ class DownIteratorJniWrapper final : public spotify::jni::JavaClass {
   void mapFields() override;
 };
 
-/// An ExternalStream that is backed by a down-iterator.
-/// What is down-iterator: A down-iterator is an iterator passed
+/// An ExternalStream that is backed by an import-iterator.
+/// What is import-iterator: An import-iterator is an iterator passed
 /// From Java to C++ for Velox to read data from Java.
-/// An instance of this class is operating on a Java-side down-iterator
+/// An instance of this class is operating on a Java-side import-iterator
 /// through JNI.
-class DownIterator : public ExternalStream {
+class ImportIterator : public ExternalStream {
  public:
   enum class State { AVAILABLE = 0, BLOCKED = 1, FINISHED = 2 };
 
   // CTOR.
-  DownIterator(JNIEnv* env, jobject ref);
+  ImportIterator(JNIEnv* env, jobject ref);
 
   // Delete copy/move CTORs.
-  DownIterator(DownIterator&&) = delete;
-  DownIterator(const DownIterator&) = delete;
-  DownIterator& operator=(const DownIterator&) = delete;
-  DownIterator& operator=(DownIterator&&) = delete;
+  ImportIterator(ImportIterator&&) = delete;
+  ImportIterator(const ImportIterator&) = delete;
+  ImportIterator& operator=(const ImportIterator&) = delete;
+  ImportIterator& operator=(ImportIterator&&) = delete;
 
   // DTOR.
-  ~DownIterator() override;
+  ~ImportIterator() override;
 
   std::optional<facebook::velox::RowVectorPtr> read(
       facebook::velox::ContinueFuture& future) override;

--- a/src/main/cpp/main/velox4j/jni/JniLoader.cc
+++ b/src/main/cpp/main/velox4j/jni/JniLoader.cc
@@ -15,7 +15,7 @@
 #include <JniHelpers.h>
 #include <glog/logging.h>
 #include <jni.h>
-#include "velox4j/iterator/DownIterator.h"
+#include "velox4j/iterator/ImportIterator.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/jni/JniError.h"
 #include "velox4j/jni/JniWrapper.h"
@@ -32,7 +32,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* jvm, void*) {
   velox4j::getJniErrorState()->ensureInitialized(env);
   velox4j::jniClassRegistry()->add(env, new velox4j::JniWrapper(env));
   velox4j::jniClassRegistry()->add(
-      env, new velox4j::DownIteratorJniWrapper(env));
+      env, new velox4j::ImportIteratorJniWrapper(env));
   velox4j::jniClassRegistry()->add(
       env, new velox4j::JavaAllocationListenerJniWrapper(env));
 

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -28,8 +28,8 @@
 #include "velox4j/eval/Evaluator.h"
 #include "velox4j/init/Init.h"
 #include "velox4j/iterator/BlockingQueue.h"
-#include "velox4j/iterator/DownIterator.h"
-#include "velox4j/iterator/UpIterator.h"
+#include "velox4j/iterator/ImportIterator.h"
+#include "velox4j/iterator/ExportIterator.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/jni/JniError.h"
 #include "velox4j/lifecycle/Session.h"
@@ -142,23 +142,23 @@ jlong queryExecutorExecute(
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 
-jint upIteratorAdvance(JNIEnv* env, jclass clazz, jlong itrId) {
+jint exportIteratorAdvance(JNIEnv* env, jclass clazz, jlong itrId) {
   JNI_METHOD_START
-  auto itr = ObjectStore::retrieve<UpIterator>(itrId);
+  auto itr = ObjectStore::retrieve<ExportIterator>(itrId);
   return static_cast<jint>(itr->advance());
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 
-void upIteratorWait(JNIEnv* env, jclass clazz, jlong itrId) {
+void exportIteratorWait(JNIEnv* env, jclass clazz, jlong itrId) {
   JNI_METHOD_START
-  auto itr = ObjectStore::retrieve<UpIterator>(itrId);
+  auto itr = ObjectStore::retrieve<ExportIterator>(itrId);
   itr->wait();
   JNI_METHOD_END()
 }
 
-jlong upIteratorGet(JNIEnv* env, jobject javaThis, jlong itrId) {
+jlong exportIteratorGet(JNIEnv* env, jobject javaThis, jlong itrId) {
   JNI_METHOD_START
-  auto itr = ObjectStore::retrieve<UpIterator>(itrId);
+  auto itr = ObjectStore::retrieve<ExportIterator>(itrId);
   return sessionOf(env, javaThis)->objectStore()->save(itr->get());
   JNI_METHOD_END(kInvalidObjectHandle)
 }
@@ -178,12 +178,12 @@ void blockingQueueNoMoreInput(JNIEnv* env, jclass clazz, jlong queueId) {
   JNI_METHOD_END()
 }
 
-jlong createExternalStreamFromDownIterator(
+jlong createExternalStreamFromImportIterator(
     JNIEnv* env,
     jobject javaThis,
     jobject itrRef) {
   JNI_METHOD_START
-  auto es = std::make_shared<DownIterator>(env, itrRef);
+  auto es = std::make_shared<ImportIterator>(env, itrRef);
   return sessionOf(env, javaThis)->objectStore()->save(es);
   JNI_METHOD_END(kInvalidObjectHandle)
 }
@@ -787,9 +787,9 @@ jlong iSerializableAsCpp(JNIEnv* env, jobject javaThis, jstring json) {
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 
-class ExternalStreamAsUpIterator : public UpIterator {
+class ExternalStreamAsExportIterator : public ExportIterator {
  public:
-  explicit ExternalStreamAsUpIterator(const std::shared_ptr<ExternalStream>& es)
+  explicit ExternalStreamAsExportIterator(const std::shared_ptr<ExternalStream>& es)
       : es_(es) {}
 
   State advance() override {
@@ -817,7 +817,7 @@ class ExternalStreamAsUpIterator : public UpIterator {
   RowVectorPtr get() override {
     VELOX_CHECK_NOT_NULL(
         pending_,
-        "ExternalStreamAsUpIterator: No pending row vector to return. Make "
+        "ExternalStreamAsExportIterator: No pending row vector to return. Make "
         "sure the iterator is available via member function advance() first");
     auto out = pending_;
     pending_ = nullptr;
@@ -829,7 +829,7 @@ class ExternalStreamAsUpIterator : public UpIterator {
   RowVectorPtr pending_{nullptr};
 };
 
-jlong createUpIteratorWithExternalStream(
+jlong createExportIteratorWithExternalStream(
     JNIEnv* env,
     jobject javaThis,
     jlong id) {
@@ -837,7 +837,7 @@ jlong createUpIteratorWithExternalStream(
   auto es = ObjectStore::retrieve<ExternalStream>(id);
   return sessionOf(env, javaThis)
       ->objectStore()
-      ->save(std::make_shared<ExternalStreamAsUpIterator>(es));
+      ->save(std::make_shared<ExternalStreamAsExportIterator>(es));
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 } // namespace
@@ -898,15 +898,15 @@ void JniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       nullptr);
   addNativeMethod(
-      "upIteratorAdvance",
-      (void*)upIteratorAdvance,
+      "exportIteratorAdvance",
+      (void*)exportIteratorAdvance,
       kTypeInt,
       kTypeLong,
       nullptr);
   addNativeMethod(
-      "upIteratorWait", (void*)upIteratorWait, kTypeVoid, kTypeLong, nullptr);
+      "exportIteratorWait", (void*)exportIteratorWait, kTypeVoid, kTypeLong, nullptr);
   addNativeMethod(
-      "upIteratorGet", (void*)upIteratorGet, kTypeLong, kTypeLong, nullptr);
+      "exportIteratorGet", (void*)exportIteratorGet, kTypeLong, kTypeLong, nullptr);
   addNativeMethod(
       "blockingQueuePut",
       (void*)blockingQueuePut,
@@ -921,10 +921,10 @@ void JniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       nullptr);
   addNativeMethod(
-      "createExternalStreamFromDownIterator",
-      (void*)createExternalStreamFromDownIterator,
+      "createExternalStreamFromImportIterator",
+      (void*)createExternalStreamFromImportIterator,
       kTypeLong,
-      "org/boostscale/velox4j/iterator/DownIterator",
+      "org/boostscale/velox4j/iterator/ImportIterator",
       nullptr);
   addNativeMethod(
       "createBlockingQueue", (void*)createBlockingQueue, kTypeLong, nullptr);
@@ -1144,8 +1144,8 @@ void JniWrapper::initialize(JNIEnv* env) {
       kTypeString,
       nullptr);
   addNativeMethod(
-      "createUpIteratorWithExternalStream",
-      (void*)createUpIteratorWithExternalStream,
+      "createExportIteratorWithExternalStream",
+      (void*)createExportIteratorWithExternalStream,
       kTypeLong,
       kTypeLong,
       nullptr);

--- a/src/main/cpp/main/velox4j/jni/JniWrapper.cc
+++ b/src/main/cpp/main/velox4j/jni/JniWrapper.cc
@@ -28,8 +28,8 @@
 #include "velox4j/eval/Evaluator.h"
 #include "velox4j/init/Init.h"
 #include "velox4j/iterator/BlockingQueue.h"
-#include "velox4j/iterator/ImportIterator.h"
 #include "velox4j/iterator/ExportIterator.h"
+#include "velox4j/iterator/ImportIterator.h"
 #include "velox4j/jni/JniCommon.h"
 #include "velox4j/jni/JniError.h"
 #include "velox4j/lifecycle/Session.h"
@@ -789,7 +789,8 @@ jlong iSerializableAsCpp(JNIEnv* env, jobject javaThis, jstring json) {
 
 class ExternalStreamAsExportIterator : public ExportIterator {
  public:
-  explicit ExternalStreamAsExportIterator(const std::shared_ptr<ExternalStream>& es)
+  explicit ExternalStreamAsExportIterator(
+      const std::shared_ptr<ExternalStream>& es)
       : es_(es) {}
 
   State advance() override {
@@ -904,9 +905,17 @@ void JniWrapper::initialize(JNIEnv* env) {
       kTypeLong,
       nullptr);
   addNativeMethod(
-      "exportIteratorWait", (void*)exportIteratorWait, kTypeVoid, kTypeLong, nullptr);
+      "exportIteratorWait",
+      (void*)exportIteratorWait,
+      kTypeVoid,
+      kTypeLong,
+      nullptr);
   addNativeMethod(
-      "exportIteratorGet", (void*)exportIteratorGet, kTypeLong, kTypeLong, nullptr);
+      "exportIteratorGet",
+      (void*)exportIteratorGet,
+      kTypeLong,
+      kTypeLong,
+      nullptr);
   addNativeMethod(
       "blockingQueuePut",
       (void*)blockingQueuePut,

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.cc
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.cc
@@ -81,7 +81,7 @@ SerialTask::~SerialTask() {
   }
 }
 
-UpIterator::State SerialTask::advance() {
+ExportIterator::State SerialTask::advance() {
   if (hasPendingState_) {
     hasPendingState_ = false;
     return pendingState_;
@@ -125,7 +125,7 @@ std::unique_ptr<SerialTaskStats> SerialTask::collectStats() {
   return std::make_unique<SerialTaskStats>(stats);
 }
 
-UpIterator::State SerialTask::advance0(bool wait) {
+ExportIterator::State SerialTask::advance0(bool wait) {
   while (true) {
     auto future = ContinueFuture::makeEmpty();
     auto out = task_->next(&future);

--- a/src/main/cpp/main/velox4j/query/QueryExecutor.h
+++ b/src/main/cpp/main/velox4j/query/QueryExecutor.h
@@ -17,7 +17,7 @@
 #include <velox/exec/Driver.h>
 #include <velox/exec/TaskStats.h>
 
-#include "velox4j/iterator/UpIterator.h"
+#include "velox4j/iterator/ExportIterator.h"
 #include "velox4j/memory/MemoryManager.h"
 #include "velox4j/query/Query.h"
 
@@ -35,9 +35,9 @@ class SerialTaskStats {
   facebook::velox::exec::TaskStats taskStats_;
 };
 
-/// An UpIterator implementation that is backed by a Velox task which is
+/// An ExportIterator implementation that is backed by a Velox task which is
 /// executed in serial execution mode.
-class SerialTask : public UpIterator {
+class SerialTask : public ExportIterator {
  public:
   SerialTask(MemoryManager* memoryManager, std::shared_ptr<const Query> query);
 

--- a/src/main/cpp/test/velox4j/query/QueryTest.cc
+++ b/src/main/cpp/test/velox4j/query/QueryTest.cc
@@ -52,20 +52,20 @@ class QueryTest : public testing::Test, public test::VectorTestBase {
         std::make_shared<MemoryManager>(AllocationListener::noop());
   }
 
-  std::vector<RowVectorPtr> collect(UpIterator& itr) {
+  std::vector<RowVectorPtr> collect(ExportIterator& itr) {
     std::vector<RowVectorPtr> out{};
     while (true) {
-      const UpIterator::State state = itr.advance();
+      const ExportIterator::State state = itr.advance();
       switch (state) {
-        case UpIterator::State::AVAILABLE: {
+        case ExportIterator::State::AVAILABLE: {
           const auto rv = itr.get();
           out.push_back(std::dynamic_pointer_cast<RowVector>(
               RowVector::loadedVectorShared(rv)));
           break;
         }
-        case UpIterator::State::BLOCKED:
+        case ExportIterator::State::BLOCKED:
           continue;
-        case UpIterator::State::FINISHED:
+        case ExportIterator::State::FINISHED:
           goto OUT;
       }
     }

--- a/src/main/java/org/boostscale/velox4j/connector/ExternalStreams.java
+++ b/src/main/java/org/boostscale/velox4j/connector/ExternalStreams.java
@@ -14,7 +14,7 @@
 package org.boostscale.velox4j.connector;
 
 import org.boostscale.velox4j.data.RowVector;
-import org.boostscale.velox4j.iterator.DownIterator;
+import org.boostscale.velox4j.iterator.ImportIterator;
 import org.boostscale.velox4j.jni.JniApi;
 
 /** A factory for creating {@link ExternalStream} instances. */
@@ -25,8 +25,8 @@ public class ExternalStreams {
     this.jniApi = jniApi;
   }
 
-  public ExternalStream bind(DownIterator itr) {
-    return jniApi.createExternalStreamFromDownIterator(itr);
+  public ExternalStream bind(ImportIterator itr) {
+    return jniApi.createExternalStreamFromImportIterator(itr);
   }
 
   /**

--- a/src/main/java/org/boostscale/velox4j/iterator/ExportIterator.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/ExportIterator.java
@@ -22,10 +22,10 @@ import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.jni.CppObject;
 
 /**
- * An up-iterator is the opposite of down-iterator. It transmits data that is output from Velox
+ * An export-iterator is the opposite of import-iterator. It transmits data that is output from Velox
  * pipeline from C++ to Java.
  */
-public interface UpIterator extends CppObject {
+public interface ExportIterator extends CppObject {
   enum State {
     AVAILABLE(0),
     BLOCKED(1),

--- a/src/main/java/org/boostscale/velox4j/iterator/ExportIterator.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/ExportIterator.java
@@ -22,8 +22,8 @@ import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.jni.CppObject;
 
 /**
- * An export-iterator is the opposite of import-iterator. It transmits data that is output from Velox
- * pipeline from C++ to Java.
+ * An export-iterator is the opposite of import-iterator. It transmits data that is output from
+ * Velox pipeline from C++ to Java.
  */
 public interface ExportIterator extends CppObject {
   enum State {

--- a/src/main/java/org/boostscale/velox4j/iterator/ExportIterators.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/ExportIterators.java
@@ -16,29 +16,29 @@ package org.boostscale.velox4j.iterator;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.exception.VeloxException;
 
-public final class UpIterators {
-  public static CloseableIterator<RowVector> asJavaIterator(UpIterator upIterator) {
-    return new AsJavaIterator(upIterator);
+public final class ExportIterators {
+  public static CloseableIterator<RowVector> asJavaIterator(ExportIterator exportIterator) {
+    return new AsJavaIterator(exportIterator);
   }
 
-  public static InfiniteIterator<RowVector> asInfiniteIterator(UpIterator upIterator) {
-    return new AsInfiniteIterator(upIterator);
+  public static InfiniteIterator<RowVector> asInfiniteIterator(ExportIterator exportIterator) {
+    return new AsInfiniteIterator(exportIterator);
   }
 
   private static class AsJavaIterator implements CloseableIterator<RowVector> {
-    private final UpIterator upIterator;
+    private final ExportIterator exportIterator;
 
-    private AsJavaIterator(UpIterator upIterator) {
-      this.upIterator = upIterator;
+    private AsJavaIterator(ExportIterator exportIterator) {
+      this.exportIterator = exportIterator;
     }
 
     @Override
     public boolean hasNext() {
       while (true) {
-        final UpIterator.State state = upIterator.advance();
+        final ExportIterator.State state = exportIterator.advance();
         switch (state) {
           case BLOCKED:
-            upIterator.waitFor();
+            exportIterator.waitFor();
             continue;
           case AVAILABLE:
             return true;
@@ -50,21 +50,21 @@ public final class UpIterators {
 
     @Override
     public RowVector next() {
-      return upIterator.get();
+      return exportIterator.get();
     }
 
     @Override
     public void close() throws Exception {
-      upIterator.close();
+      exportIterator.close();
     }
   }
 
   private static class AsInfiniteIterator implements InfiniteIterator<RowVector> {
-    private final UpIterator upIterator;
+    private final ExportIterator exportIterator;
     private boolean isAvailable = false;
 
-    private AsInfiniteIterator(UpIterator upIterator) {
-      this.upIterator = upIterator;
+    private AsInfiniteIterator(ExportIterator exportIterator) {
+      this.exportIterator = exportIterator;
     }
 
     @Override
@@ -72,7 +72,7 @@ public final class UpIterators {
       if (isAvailable) {
         return true;
       }
-      final UpIterator.State state = upIterator.advance();
+      final ExportIterator.State state = exportIterator.advance();
       switch (state) {
         case BLOCKED:
           return false;
@@ -92,10 +92,10 @@ public final class UpIterators {
       if (isAvailable) {
         return;
       }
-      final UpIterator.State state = upIterator.advance();
+      final ExportIterator.State state = exportIterator.advance();
       switch (state) {
         case BLOCKED:
-          upIterator.waitFor();
+          exportIterator.waitFor();
           return;
         case AVAILABLE:
           isAvailable = true;
@@ -114,14 +114,14 @@ public final class UpIterators {
         throw new VeloxException(
             "AsInfiniteIterator#get can only be called after #available() returns true");
       }
-      final RowVector rv = upIterator.get();
+      final RowVector rv = exportIterator.get();
       isAvailable = false;
       return rv;
     }
 
     @Override
     public void close() throws Exception {
-      upIterator.close();
+      exportIterator.close();
     }
   }
 }

--- a/src/main/java/org/boostscale/velox4j/iterator/GenericExportIterator.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/GenericExportIterator.java
@@ -16,28 +16,28 @@ package org.boostscale.velox4j.iterator;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.jni.JniApi;
 
-public class GenericUpIterator implements UpIterator {
+public class GenericExportIterator implements ExportIterator {
   private final JniApi jniApi;
   private final long id;
 
-  public GenericUpIterator(JniApi jniApi, long id) {
+  public GenericExportIterator(JniApi jniApi, long id) {
     this.jniApi = jniApi;
     this.id = id;
   }
 
   @Override
   public State advance() {
-    return JniApi.upIteratorAdvance(this);
+    return JniApi.exportIteratorAdvance(this);
   }
 
   @Override
   public void waitFor() {
-    JniApi.upIteratorWait(this);
+    JniApi.exportIteratorWait(this);
   }
 
   @Override
   public RowVector get() {
-    return jniApi.upIteratorGet(this);
+    return jniApi.exportIteratorGet(this);
   }
 
   @Override

--- a/src/main/java/org/boostscale/velox4j/iterator/ImportIterator.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/ImportIterator.java
@@ -16,10 +16,10 @@ package org.boostscale.velox4j.iterator;
 import org.boostscale.velox4j.jni.CalledFromNative;
 
 /**
- * An ExternalStream that is backed by a down-iterator. What is down-iterator: A down-iterator is an
+ * An ExternalStream that is backed by an import-iterator. What is import-iterator: An import-iterator is an
  * iterator passed From Java to C++ for Velox to read data from Java.
  */
-public interface DownIterator {
+public interface ImportIterator {
   enum State {
     AVAILABLE(0),
     BLOCKED(1),
@@ -51,7 +51,7 @@ public interface DownIterator {
   @CalledFromNative
   long get();
 
-  /** Closes the down-iterator. */
+  /** Closes the import-iterator. */
   @CalledFromNative
   void close();
 }

--- a/src/main/java/org/boostscale/velox4j/iterator/ImportIterator.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/ImportIterator.java
@@ -16,8 +16,8 @@ package org.boostscale.velox4j.iterator;
 import org.boostscale.velox4j.jni.CalledFromNative;
 
 /**
- * An ExternalStream that is backed by an import-iterator. What is import-iterator: An import-iterator is an
- * iterator passed From Java to C++ for Velox to read data from Java.
+ * An ExternalStream that is backed by an import-iterator. What is import-iterator: An
+ * import-iterator is an iterator passed From Java to C++ for Velox to read data from Java.
  */
 public interface ImportIterator {
   enum State {

--- a/src/main/java/org/boostscale/velox4j/iterator/ImportIterators.java
+++ b/src/main/java/org/boostscale/velox4j/iterator/ImportIterators.java
@@ -17,13 +17,13 @@ import java.util.Iterator;
 
 import org.boostscale.velox4j.data.RowVector;
 
-public final class DownIterators {
-  /** Creates a down-iterator instance from a given Java iterator. */
-  public static DownIterator fromJavaIterator(Iterator<RowVector> itr) {
+public final class ImportIterators {
+  /** Creates an import-iterator instance from a given Java iterator. */
+  public static ImportIterator fromJavaIterator(Iterator<RowVector> itr) {
     return new FromJavaIterator(itr);
   }
 
-  private static class FromJavaIterator extends BaseDownIterator {
+  private static class FromJavaIterator extends BaseImportIterator {
     private final Iterator<RowVector> itr;
 
     private FromJavaIterator(Iterator<RowVector> itr) {
@@ -52,8 +52,8 @@ public final class DownIterators {
     public void close() {}
   }
 
-  private abstract static class BaseDownIterator implements DownIterator {
-    protected BaseDownIterator() {}
+  private abstract static class BaseImportIterator implements ImportIterator {
+    protected BaseImportIterator() {}
 
     @Override
     public final int advance() {
@@ -65,7 +65,7 @@ public final class DownIterators {
       return get0().id();
     }
 
-    protected abstract DownIterator.State advance0();
+    protected abstract ImportIterator.State advance0();
 
     protected abstract RowVector get0();
   }

--- a/src/main/java/org/boostscale/velox4j/jni/JniApi.java
+++ b/src/main/java/org/boostscale/velox4j/jni/JniApi.java
@@ -28,9 +28,9 @@ import org.boostscale.velox4j.connector.ExternalStreams;
 import org.boostscale.velox4j.data.*;
 import org.boostscale.velox4j.eval.Evaluation;
 import org.boostscale.velox4j.eval.Evaluator;
-import org.boostscale.velox4j.iterator.ImportIterator;
-import org.boostscale.velox4j.iterator.GenericExportIterator;
 import org.boostscale.velox4j.iterator.ExportIterator;
+import org.boostscale.velox4j.iterator.GenericExportIterator;
+import org.boostscale.velox4j.iterator.ImportIterator;
 import org.boostscale.velox4j.memory.AllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
 import org.boostscale.velox4j.partition.PartitionFunction;
@@ -129,7 +129,8 @@ public final class JniApi {
   }
 
   public ExternalStream createExternalStreamFromImportIterator(ImportIterator itr) {
-    return new ExternalStreams.GenericExternalStream(jni.createExternalStreamFromImportIterator(itr));
+    return new ExternalStreams.GenericExternalStream(
+        jni.createExternalStreamFromImportIterator(itr));
   }
 
   public ExternalStreams.BlockingQueue createBlockingQueue() {

--- a/src/main/java/org/boostscale/velox4j/jni/JniApi.java
+++ b/src/main/java/org/boostscale/velox4j/jni/JniApi.java
@@ -28,9 +28,9 @@ import org.boostscale.velox4j.connector.ExternalStreams;
 import org.boostscale.velox4j.data.*;
 import org.boostscale.velox4j.eval.Evaluation;
 import org.boostscale.velox4j.eval.Evaluator;
-import org.boostscale.velox4j.iterator.DownIterator;
-import org.boostscale.velox4j.iterator.GenericUpIterator;
-import org.boostscale.velox4j.iterator.UpIterator;
+import org.boostscale.velox4j.iterator.ImportIterator;
+import org.boostscale.velox4j.iterator.GenericExportIterator;
+import org.boostscale.velox4j.iterator.ExportIterator;
 import org.boostscale.velox4j.memory.AllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
 import org.boostscale.velox4j.partition.PartitionFunction;
@@ -106,20 +106,20 @@ public final class JniApi {
     return new SerialTask(this, jni.queryExecutorExecute(executor.id()));
   }
 
-  // UpIterator.
-  public static UpIterator.State upIteratorAdvance(UpIterator itr) {
-    return UpIterator.State.get(JniWrapper.upIteratorAdvance(itr.id()));
+  // ExportIterator.
+  public static ExportIterator.State exportIteratorAdvance(ExportIterator itr) {
+    return ExportIterator.State.get(JniWrapper.exportIteratorAdvance(itr.id()));
   }
 
-  public static void upIteratorWait(UpIterator itr) {
-    JniWrapper.upIteratorWait(itr.id());
+  public static void exportIteratorWait(ExportIterator itr) {
+    JniWrapper.exportIteratorWait(itr.id());
   }
 
-  public RowVector upIteratorGet(UpIterator itr) {
-    return baseVectorCreateById(jni.upIteratorGet(itr.id())).asRowVector();
+  public RowVector exportIteratorGet(ExportIterator itr) {
+    return baseVectorCreateById(jni.exportIteratorGet(itr.id())).asRowVector();
   }
 
-  // DownIterator.
+  // ImportIterator.
   public static void blockingQueuePut(ExternalStreams.BlockingQueue queue, RowVector rowVector) {
     JniWrapper.blockingQueuePut(queue.id(), rowVector.id());
   }
@@ -128,8 +128,8 @@ public final class JniApi {
     JniWrapper.blockingQueueNoMoreInput(queue.id());
   }
 
-  public ExternalStream createExternalStreamFromDownIterator(DownIterator itr) {
-    return new ExternalStreams.GenericExternalStream(jni.createExternalStreamFromDownIterator(itr));
+  public ExternalStream createExternalStreamFromImportIterator(ImportIterator itr) {
+    return new ExternalStreams.GenericExternalStream(jni.createExternalStreamFromImportIterator(itr));
   }
 
   public ExternalStreams.BlockingQueue createBlockingQueue() {
@@ -335,8 +335,8 @@ public final class JniApi {
   }
 
   @VisibleForTesting
-  public UpIterator createUpIteratorWithExternalStream(ExternalStream es) {
-    return new GenericUpIterator(this, jni.createUpIteratorWithExternalStream(es.id()));
+  public ExportIterator createExportIteratorWithExternalStream(ExternalStream es) {
+    return new GenericExportIterator(this, jni.createExportIteratorWithExternalStream(es.id()));
   }
 
   private BaseVector baseVectorCreateById(long id) {

--- a/src/main/java/org/boostscale/velox4j/jni/JniWrapper.java
+++ b/src/main/java/org/boostscale/velox4j/jni/JniWrapper.java
@@ -15,7 +15,7 @@ package org.boostscale.velox4j.jni;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.boostscale.velox4j.iterator.DownIterator;
+import org.boostscale.velox4j.iterator.ImportIterator;
 import org.boostscale.velox4j.memory.AllocationListener;
 
 /** JNI native method declarations for both global and session-aware APIs. */
@@ -52,19 +52,19 @@ final class JniWrapper {
 
   native long queryExecutorExecute(long id);
 
-  // For UpIterator.
-  static native int upIteratorAdvance(long id);
+  // For ExportIterator.
+  static native int exportIteratorAdvance(long id);
 
-  static native void upIteratorWait(long id);
+  static native void exportIteratorWait(long id);
 
-  native long upIteratorGet(long id);
+  native long exportIteratorGet(long id);
 
-  // For DownIterator.
+  // For ImportIterator.
   static native void blockingQueuePut(long id, long rvId);
 
   static native void blockingQueueNoMoreInput(long id);
 
-  native long createExternalStreamFromDownIterator(DownIterator itr);
+  native long createExternalStreamFromImportIterator(ImportIterator itr);
 
   native long createBlockingQueue();
 
@@ -147,5 +147,5 @@ final class JniWrapper {
   native long iSerializableAsCpp(String json);
 
   @VisibleForTesting
-  native long createUpIteratorWithExternalStream(long id);
+  native long createExportIteratorWithExternalStream(long id);
 }

--- a/src/main/java/org/boostscale/velox4j/query/SerialTask.java
+++ b/src/main/java/org/boostscale/velox4j/query/SerialTask.java
@@ -15,13 +15,13 @@ package org.boostscale.velox4j.query;
 
 import org.boostscale.velox4j.connector.ConnectorSplit;
 import org.boostscale.velox4j.data.RowVector;
-import org.boostscale.velox4j.iterator.UpIterator;
+import org.boostscale.velox4j.iterator.ExportIterator;
 import org.boostscale.velox4j.jni.JniApi;
 
 /**
- * An up-iterator implementation that is backed by a Velox task that runs in serial execution mode.
+ * An export-iterator implementation that is backed by a Velox task that runs in serial execution mode.
  */
-public class SerialTask implements UpIterator {
+public class SerialTask implements ExportIterator {
   private final JniApi jniApi;
   private final long id;
 
@@ -32,17 +32,17 @@ public class SerialTask implements UpIterator {
 
   @Override
   public State advance() {
-    return JniApi.upIteratorAdvance(this);
+    return JniApi.exportIteratorAdvance(this);
   }
 
   @Override
   public void waitFor() {
-    JniApi.upIteratorWait(this);
+    JniApi.exportIteratorWait(this);
   }
 
   @Override
   public RowVector get() {
-    return jniApi.upIteratorGet(this);
+    return jniApi.exportIteratorGet(this);
   }
 
   @Override

--- a/src/main/java/org/boostscale/velox4j/query/SerialTask.java
+++ b/src/main/java/org/boostscale/velox4j/query/SerialTask.java
@@ -19,7 +19,8 @@ import org.boostscale.velox4j.iterator.ExportIterator;
 import org.boostscale.velox4j.jni.JniApi;
 
 /**
- * An export-iterator implementation that is backed by a Velox task that runs in serial execution mode.
+ * An export-iterator implementation that is backed by a Velox task that runs in serial execution
+ * mode.
  */
 public class SerialTask implements ExportIterator {
   private final JniApi jniApi;

--- a/src/test/java/org/boostscale/velox4j/jni/JniApiTest.java
+++ b/src/test/java/org/boostscale/velox4j/jni/JniApiTest.java
@@ -32,17 +32,17 @@ import org.boostscale.velox4j.data.BaseVector;
 import org.boostscale.velox4j.data.BaseVectorTests;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.exception.VeloxException;
-import org.boostscale.velox4j.iterator.DownIterator;
-import org.boostscale.velox4j.iterator.DownIterators;
-import org.boostscale.velox4j.iterator.UpIterator;
-import org.boostscale.velox4j.iterator.UpIterators;
+import org.boostscale.velox4j.iterator.ImportIterator;
+import org.boostscale.velox4j.iterator.ImportIterators;
+import org.boostscale.velox4j.iterator.ExportIterator;
+import org.boostscale.velox4j.iterator.ExportIterators;
 import org.boostscale.velox4j.memory.BytesAllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
 import org.boostscale.velox4j.query.QueryExecutor;
 import org.boostscale.velox4j.session.Session;
 import org.boostscale.velox4j.test.SampleQueryTests;
 import org.boostscale.velox4j.test.TestThreads;
-import org.boostscale.velox4j.test.UpIteratorTests;
+import org.boostscale.velox4j.test.ExportIteratorTests;
 import org.boostscale.velox4j.test.Velox4jTests;
 import org.boostscale.velox4j.type.DoubleType;
 import org.boostscale.velox4j.type.IntegerType;
@@ -105,7 +105,7 @@ public class JniApiTest {
     final LocalSession session = createLocalSession(memoryManager);
     final JniApi jniApi = getJniApi(session);
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
+    final ExportIterator itr = queryExecutor.execute();
     itr.close();
     session.close();
   }
@@ -116,7 +116,7 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
+    final ExportIterator itr = queryExecutor.execute();
     SampleQueryTests.assertIterator(itr);
     session.close();
     ;
@@ -128,8 +128,8 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr1 = queryExecutor.execute();
-    final UpIterator itr2 = queryExecutor.execute();
+    final ExportIterator itr1 = queryExecutor.execute();
+    final ExportIterator itr2 = queryExecutor.execute();
     SampleQueryTests.assertIterator(itr1);
     SampleQueryTests.assertIterator(itr2);
     session.close();
@@ -155,8 +155,8 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
-    final RowVector vector = UpIteratorTests.collectSingleVector(itr);
+    final ExportIterator itr = queryExecutor.execute();
+    final RowVector vector = ExportIteratorTests.collectSingleVector(itr);
     final List<RowVector> vectors = ImmutableList.of(vector);
     final String serialized = JniApi.baseVectorSerialize(vectors);
     final List<BaseVector> deserialized = jniApi.baseVectorDeserialize(serialized);
@@ -171,8 +171,8 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
-    final RowVector vector = UpIteratorTests.collectSingleVector(itr);
+    final ExportIterator itr = queryExecutor.execute();
+    final RowVector vector = ExportIteratorTests.collectSingleVector(itr);
     final List<RowVector> vectors = ImmutableList.of(vector, vector);
     final String serialized = JniApi.baseVectorSerialize(vectors);
     final List<BaseVector> deserialized = jniApi.baseVectorDeserialize(serialized);
@@ -186,8 +186,8 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
-    final RowVector vector = UpIteratorTests.collectSingleVector(itr);
+    final ExportIterator itr = queryExecutor.execute();
+    final RowVector vector = ExportIteratorTests.collectSingleVector(itr);
     final FieldVector arrowVector = Arrow.toArrowVector(arrowAlloc, vector);
     final BaseVector imported = session.arrowOps().fromArrowVector(arrowAlloc, arrowVector);
     BaseVectorTests.assertEquals(vector, imported);
@@ -208,10 +208,10 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
-    final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
-    final ExternalStream es = jniApi.createExternalStreamFromDownIterator(down);
-    final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);
+    final ExportIterator itr = queryExecutor.execute();
+    final ImportIterator down = ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(itr));
+    final ExternalStream es = jniApi.createExternalStreamFromImportIterator(down);
+    final ExportIterator up = jniApi.createExportIteratorWithExternalStream(es);
     SampleQueryTests.assertIterator(up);
     session.close();
   }
@@ -222,10 +222,10 @@ public class JniApiTest {
     final JniApi jniApi = getJniApi(session);
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
-    final UpIterator itr = queryExecutor.execute();
-    final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(itr));
-    final ExternalStream es = jniApi.createExternalStreamFromDownIterator(down);
-    final UpIterator up = jniApi.createUpIteratorWithExternalStream(es);
+    final ExportIterator itr = queryExecutor.execute();
+    final ImportIterator down = ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(itr));
+    final ExternalStream es = jniApi.createExternalStreamFromImportIterator(down);
+    final ExportIterator up = jniApi.createExportIteratorWithExternalStream(es);
     final Thread thread =
         TestThreads.newTestThread(
             new Runnable() {

--- a/src/test/java/org/boostscale/velox4j/jni/JniApiTest.java
+++ b/src/test/java/org/boostscale/velox4j/jni/JniApiTest.java
@@ -32,17 +32,17 @@ import org.boostscale.velox4j.data.BaseVector;
 import org.boostscale.velox4j.data.BaseVectorTests;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.exception.VeloxException;
-import org.boostscale.velox4j.iterator.ImportIterator;
-import org.boostscale.velox4j.iterator.ImportIterators;
 import org.boostscale.velox4j.iterator.ExportIterator;
 import org.boostscale.velox4j.iterator.ExportIterators;
+import org.boostscale.velox4j.iterator.ImportIterator;
+import org.boostscale.velox4j.iterator.ImportIterators;
 import org.boostscale.velox4j.memory.BytesAllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
 import org.boostscale.velox4j.query.QueryExecutor;
 import org.boostscale.velox4j.session.Session;
+import org.boostscale.velox4j.test.ExportIteratorTests;
 import org.boostscale.velox4j.test.SampleQueryTests;
 import org.boostscale.velox4j.test.TestThreads;
-import org.boostscale.velox4j.test.ExportIteratorTests;
 import org.boostscale.velox4j.test.Velox4jTests;
 import org.boostscale.velox4j.type.DoubleType;
 import org.boostscale.velox4j.type.IntegerType;
@@ -209,7 +209,8 @@ public class JniApiTest {
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
     final ExportIterator itr = queryExecutor.execute();
-    final ImportIterator down = ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(itr));
+    final ImportIterator down =
+        ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(itr));
     final ExternalStream es = jniApi.createExternalStreamFromImportIterator(down);
     final ExportIterator up = jniApi.createExportIteratorWithExternalStream(es);
     SampleQueryTests.assertIterator(up);
@@ -223,7 +224,8 @@ public class JniApiTest {
     final String json = SampleQueryTests.readQueryJson();
     final QueryExecutor queryExecutor = jniApi.createQueryExecutor(json);
     final ExportIterator itr = queryExecutor.execute();
-    final ImportIterator down = ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(itr));
+    final ImportIterator down =
+        ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(itr));
     final ExternalStream es = jniApi.createExternalStreamFromImportIterator(down);
     final ExportIterator up = jniApi.createExportIteratorWithExternalStream(es);
     final Thread thread =

--- a/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
+++ b/src/test/java/org/boostscale/velox4j/memory/MemoryPoolNameCollisionTest.java
@@ -32,7 +32,7 @@ import org.boostscale.velox4j.connector.ExternalStreams;
 import org.boostscale.velox4j.data.BaseVectorTests;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.iterator.CloseableIterator;
-import org.boostscale.velox4j.iterator.UpIterators;
+import org.boostscale.velox4j.iterator.ExportIterators;
 import org.boostscale.velox4j.plan.TableScanNode;
 import org.boostscale.velox4j.query.Query;
 import org.boostscale.velox4j.query.SerialTask;
@@ -175,7 +175,7 @@ public class MemoryPoolNameCollisionTest {
     queue.put(rv);
     queue.noMoreInput();
 
-    CloseableIterator<RowVector> iter = UpIterators.asJavaIterator(task);
+    CloseableIterator<RowVector> iter = ExportIterators.asJavaIterator(task);
     int count = 0;
     while (iter.hasNext()) {
       RowVector result = iter.next();

--- a/src/test/java/org/boostscale/velox4j/query/QueryTest.java
+++ b/src/test/java/org/boostscale/velox4j/query/QueryTest.java
@@ -269,7 +269,8 @@ public class QueryTest {
   public void testExternalStreamFromJavaIterator() {
     final String json = SampleQueryTests.readQueryJson();
     final ExportIterator sampleIn = session.queryOps().execute(Serde.fromJson(json, Query.class));
-    final ImportIterator down = ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(sampleIn));
+    final ImportIterator down =
+        ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(sampleIn));
     final ExternalStream es = session.externalStreamOps().bind(down);
     final TableScanNode scanNode =
         new TableScanNode(

--- a/src/test/java/org/boostscale/velox4j/query/QueryTest.java
+++ b/src/test/java/org/boostscale/velox4j/query/QueryTest.java
@@ -127,7 +127,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-table-scan-nation.tsv"))
@@ -144,7 +144,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-table-scan-region.tsv"))
@@ -168,7 +168,7 @@ public class QueryTest {
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
     final List<RowVector> allRvs =
-        Streams.fromIterator(UpIterators.asJavaIterator(task))
+        Streams.fromIterator(ExportIterators.asJavaIterator(task))
             .map(v -> v.flattenedVector().asRowVector())
             .collect(Collectors.toList());
     Assert.assertTrue(allRvs.size() > 1);
@@ -202,7 +202,7 @@ public class QueryTest {
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
     final List<RowVector> allRvs =
-        Streams.fromIterator(UpIterators.asJavaIterator(task)).collect(Collectors.toList());
+        Streams.fromIterator(ExportIterators.asJavaIterator(task)).collect(Collectors.toList());
     Assert.assertTrue(allRvs.size() > 1);
     for (int i = 0; i < allRvs.size(); i++) {
       final RowVector rv = allRvs.get(i);
@@ -230,7 +230,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-aggregate-1.tsv"))
@@ -250,7 +250,7 @@ public class QueryTest {
     final SerialTask serialTask = session.queryOps().execute(query);
     serialTask.addSplit(scanNode.getId(), split);
     serialTask.noMoreSplits(scanNode.getId());
-    UpIteratorTests.collect(serialTask);
+    ExportIteratorTests.collect(serialTask);
     final SerialTaskStats serialTaskStats = serialTask.collectStats();
 
     final JsonNode scanStats = serialTaskStats.planStats("id-1");
@@ -268,8 +268,8 @@ public class QueryTest {
   @Test
   public void testExternalStreamFromJavaIterator() {
     final String json = SampleQueryTests.readQueryJson();
-    final UpIterator sampleIn = session.queryOps().execute(Serde.fromJson(json, Query.class));
-    final DownIterator down = DownIterators.fromJavaIterator(UpIterators.asJavaIterator(sampleIn));
+    final ExportIterator sampleIn = session.queryOps().execute(Serde.fromJson(json, Query.class));
+    final ImportIterator down = ImportIterators.fromJavaIterator(ExportIterators.asJavaIterator(sampleIn));
     final ExternalStream es = session.externalStreamOps().bind(down);
     final TableScanNode scanNode =
         new TableScanNode(
@@ -288,7 +288,7 @@ public class QueryTest {
 
   @Test
   public void testExternalStreamFromEmptyJavaIterator() {
-    final DownIterator down = DownIterators.fromJavaIterator(Collections.emptyIterator());
+    final ImportIterator down = ImportIterators.fromJavaIterator(Collections.emptyIterator());
     final ExternalStream es = session.externalStreamOps().bind(down);
     final TableScanNode scanNode =
         new TableScanNode(
@@ -302,7 +302,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task).assertNumRowVectors(0).run();
+    ExportIteratorTests.assertIterator(task).assertNumRowVectors(0).run();
   }
 
   @Test
@@ -324,34 +324,34 @@ public class QueryTest {
 
     // No input added, the up-iterator is considered blocked.
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     // Add one input.
     queue.put(rv);
     task.waitFor();
-    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
     Assert.assertThrows(VeloxException.class, task::advance);
     BaseVectorTests.assertEquals(rv, task.get());
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     // Add multiple inputs at a time.
     queue.put(rv);
     queue.put(rv);
     task.waitFor();
     Assert.assertThrows(VeloxException.class, task::waitFor);
-    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
     Assert.assertThrows(VeloxException.class, task::advance);
     BaseVectorTests.assertEquals(rv, task.get());
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
     Assert.assertThrows(VeloxException.class, task::advance);
     BaseVectorTests.assertEquals(rv, task.get());
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
   }
 
   @Test
@@ -373,27 +373,27 @@ public class QueryTest {
 
     // No input added, the up-iterator is considered blocked.
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     // Add one input.
     queue.put(rv);
     task.waitFor();
-    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
     Assert.assertThrows(VeloxException.class, task::advance);
     BaseVectorTests.assertEquals(rv, task.get());
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     // Add another input, then signal no-more-input.
     queue.put(rv);
     queue.noMoreInput();
     task.waitFor();
-    Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+    Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
     Assert.assertThrows(VeloxException.class, task::advance);
     BaseVectorTests.assertEquals(rv, task.get());
-    Assert.assertEquals(UpIterator.State.FINISHED, task.advance());
+    Assert.assertEquals(ExportIterator.State.FINISHED, task.advance());
     Assert.assertThrows(VeloxException.class, task::get);
   }
 
@@ -417,12 +417,12 @@ public class QueryTest {
         TestThreads.newTestThread(
             () -> {
               while (true) {
-                final UpIterator.State state = task.advance();
-                if (state == UpIterator.State.BLOCKED) {
+                final ExportIterator.State state = task.advance();
+                if (state == ExportIterator.State.BLOCKED) {
                   task.waitFor();
                   continue;
                 }
-                Assert.assertEquals(UpIterator.State.FINISHED, state);
+                Assert.assertEquals(ExportIterator.State.FINISHED, state);
                 Assert.assertThrows(VeloxException.class, task::get);
                 break;
               }
@@ -454,7 +454,7 @@ public class QueryTest {
       final SerialTask task = session.queryOps().execute(query);
       task.addSplit(scanNode.getId(), split);
       task.noMoreSplits(scanNode.getId());
-      out = UpIterators.asInfiniteIterator(task);
+      out = ExportIterators.asInfiniteIterator(task);
     }
 
     // No input added, the iterator is not available.
@@ -531,8 +531,8 @@ public class QueryTest {
 
     // No input added, the up-iterator is considered blocked.
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     final Thread testThread =
         TestThreads.newTestThread(
@@ -546,12 +546,12 @@ public class QueryTest {
                   // The wait calls should not throw.
                   task.waitFor();
                   Assert.assertThrows(VeloxException.class, task::waitFor);
-                  Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+                  Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
                   Assert.assertThrows(VeloxException.class, task::advance);
                   BaseVectorTests.assertEquals(rv, task.get());
                   Assert.assertThrows(VeloxException.class, task::get);
-                  Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-                  Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+                  Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+                  Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
                   // Signals the main thread to add two inputs after 500ms.
                   control.notifyAll();
@@ -560,16 +560,16 @@ public class QueryTest {
                   // The wait calls should not throw.
                   task.waitFor();
                   Assert.assertThrows(VeloxException.class, task::waitFor);
-                  Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+                  Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
                   Assert.assertThrows(VeloxException.class, task::advance);
                   BaseVectorTests.assertEquals(rv, task.get());
                   Assert.assertThrows(VeloxException.class, task::get);
-                  Assert.assertEquals(UpIterator.State.AVAILABLE, task.advance());
+                  Assert.assertEquals(ExportIterator.State.AVAILABLE, task.advance());
                   Assert.assertThrows(VeloxException.class, task::advance);
                   BaseVectorTests.assertEquals(rv, task.get());
                   Assert.assertThrows(VeloxException.class, task::get);
-                  Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-                  Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+                  Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+                  Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
                   // Signals the main thread that the test has passed.
                   control.notifyAll();
@@ -645,21 +645,21 @@ public class QueryTest {
 
     // No input added, the up-iterator is considered blocked.
     Assert.assertThrows(VeloxException.class, task::get);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     // Add one input.
     queue.put(rv);
     Thread.sleep(500L);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
 
     // Add multiple inputs at a time.
     queue.put(rv);
     queue.put(rv);
     Thread.sleep(500L);
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
-    Assert.assertEquals(UpIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
+    Assert.assertEquals(ExportIterator.State.BLOCKED, task.advance());
   }
 
   @Test
@@ -680,7 +680,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-project-1.tsv"))
@@ -707,7 +707,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-filter-1.tsv"))
@@ -746,7 +746,7 @@ public class QueryTest {
     task.addSplit(regionScanNode.getId(), regionSplit);
     task.noMoreSplits(nationScanNode.getId());
     task.noMoreSplits(regionScanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-join-1.tsv"))
@@ -772,7 +772,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-orderby-1.tsv"))
@@ -790,7 +790,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-limit-1.tsv"))
@@ -819,7 +819,7 @@ public class QueryTest {
     task.addSplit(scanNode2.getId(), split2);
     task.noMoreSplits(scanNode2.getId());
 
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(2)
         .assertRowVectorsToString(
             ResourceTests.readResourceAsString("query-output/tpch-local-partition-gather-1.tsv"))
@@ -840,7 +840,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorTypeJson(
             0, ResourceTests.readResourceAsString("query-output-type/tpch-table-write-1.json"))
@@ -863,7 +863,7 @@ public class QueryTest {
     final SerialTask task1 = session.queryOps().execute(query1);
     task1.addSplit(scanNode1.getId(), split1);
     task1.noMoreSplits(scanNode1.getId());
-    UpIteratorTests.assertIterator(task1)
+    ExportIteratorTests.assertIterator(task1)
         .assertNumRowVectors(1)
         .assertRowVectorTypeJson(
             0, ResourceTests.readResourceAsString("query-output-type/tpch-table-write-1.json"))
@@ -878,7 +878,7 @@ public class QueryTest {
     final SerialTask task2 = session.queryOps().execute(query2);
     task2.addSplit(scanNode2.getId(), splits2);
     task2.noMoreSplits(scanNode2.getId());
-    UpIteratorTests.assertIterator(task2)
+    ExportIteratorTests.assertIterator(task2)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-table-scan-nation.tsv"))
@@ -917,7 +917,7 @@ public class QueryTest {
     final SerialTask task = session.queryOps().execute(query);
     task.addSplit(scanNode.getId(), split);
     task.noMoreSplits(scanNode.getId());
-    UpIteratorTests.assertIterator(task)
+    ExportIteratorTests.assertIterator(task)
         .assertNumRowVectors(1)
         .assertRowVectorToString(
             0, ResourceTests.readResourceAsString("query-output/tpch-window-1.tsv"))

--- a/src/test/java/org/boostscale/velox4j/query/ShuffleJoinTest.java
+++ b/src/test/java/org/boostscale/velox4j/query/ShuffleJoinTest.java
@@ -30,7 +30,7 @@ import org.boostscale.velox4j.data.BaseVector;
 import org.boostscale.velox4j.data.BaseVectors;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.expression.FieldAccessTypedExpr;
-import org.boostscale.velox4j.iterator.UpIterators;
+import org.boostscale.velox4j.iterator.ExportIterators;
 import org.boostscale.velox4j.join.JoinType;
 import org.boostscale.velox4j.memory.BytesAllocationListener;
 import org.boostscale.velox4j.memory.MemoryManager;
@@ -182,7 +182,7 @@ public class ShuffleJoinTest {
       task.noMoreSplits("left-scan");
       task.noMoreSplits("right-scan");
 
-      Iterator<RowVector> results = UpIterators.asJavaIterator(task);
+      Iterator<RowVector> results = ExportIterators.asJavaIterator(task);
       while (results.hasNext()) {
         RowVector batch = results.next();
         totalJoinedRows += batch.getSize();
@@ -273,7 +273,7 @@ public class ShuffleJoinTest {
     task.noMoreSplits("right-scan");
 
     int totalRows = 0;
-    Iterator<RowVector> results = UpIterators.asJavaIterator(task);
+    Iterator<RowVector> results = ExportIterators.asJavaIterator(task);
     while (results.hasNext()) {
       totalRows += results.next().getSize();
     }
@@ -291,7 +291,7 @@ public class ShuffleJoinTest {
     task.noMoreSplits(scan.getId());
 
     List<RowVector> batches = new ArrayList<>();
-    Iterator<RowVector> itr = UpIterators.asJavaIterator(task);
+    Iterator<RowVector> itr = ExportIterators.asJavaIterator(task);
     while (itr.hasNext()) {
       batches.add(itr.next());
     }

--- a/src/test/java/org/boostscale/velox4j/test/ExportIteratorTests.java
+++ b/src/test/java/org/boostscale/velox4j/test/ExportIteratorTests.java
@@ -26,24 +26,24 @@ import org.boostscale.velox4j.collection.Streams;
 import org.boostscale.velox4j.data.BaseVectors;
 import org.boostscale.velox4j.data.RowVector;
 import org.boostscale.velox4j.iterator.CloseableIterator;
-import org.boostscale.velox4j.iterator.UpIterator;
-import org.boostscale.velox4j.iterator.UpIterators;
+import org.boostscale.velox4j.iterator.ExportIterator;
+import org.boostscale.velox4j.iterator.ExportIterators;
 import org.boostscale.velox4j.serde.Serde;
 
-public final class UpIteratorTests {
-  public static RowVector collectSingleVector(UpIterator itr) {
+public final class ExportIteratorTests {
+  public static RowVector collectSingleVector(ExportIterator itr) {
     final List<RowVector> vectors = collect(itr);
     Assert.assertEquals(1, vectors.size());
     return vectors.get(0);
   }
 
-  public static List<RowVector> collect(UpIterator itr) {
+  public static List<RowVector> collect(ExportIterator itr) {
     final List<RowVector> vectors =
-        Streams.fromIterator(UpIterators.asJavaIterator(itr)).collect(Collectors.toList());
+        Streams.fromIterator(ExportIterators.asJavaIterator(itr)).collect(Collectors.toList());
     return vectors;
   }
 
-  public static IteratorAssertionBuilder assertIterator(UpIterator itr) {
+  public static IteratorAssertionBuilder assertIterator(ExportIterator itr) {
     return new IteratorAssertionBuilder(itr);
   }
 
@@ -53,8 +53,8 @@ public final class UpIteratorTests {
     private final List<Consumer<Argument>> assertions = new ArrayList<>();
     private final List<Runnable> finalAssertions = new ArrayList<>();
 
-    private IteratorAssertionBuilder(UpIterator itr) {
-      this.itr = UpIterators.asJavaIterator(itr);
+    private IteratorAssertionBuilder(ExportIterator itr) {
+      this.itr = ExportIterators.asJavaIterator(itr);
     }
 
     public IteratorAssertionBuilder assertNumRowVectors(int expected) {

--- a/src/test/java/org/boostscale/velox4j/test/SampleQueryTests.java
+++ b/src/test/java/org/boostscale/velox4j/test/SampleQueryTests.java
@@ -15,7 +15,7 @@ package org.boostscale.velox4j.test;
 
 import com.google.common.collect.ImmutableList;
 
-import org.boostscale.velox4j.iterator.UpIterator;
+import org.boostscale.velox4j.iterator.ExportIterator;
 import org.boostscale.velox4j.type.BigIntType;
 import org.boostscale.velox4j.type.RowType;
 
@@ -35,13 +35,13 @@ public final class SampleQueryTests {
     return ResourceTests.readResourceAsString(SAMPLE_QUERY_PATH);
   }
 
-  public static void assertIterator(UpIterator itr) {
+  public static void assertIterator(ExportIterator itr) {
     assertIterator(itr, 1);
   }
 
-  public static void assertIterator(UpIterator itr, int repeatTimes) {
-    UpIteratorTests.IteratorAssertionBuilder builder =
-        UpIteratorTests.assertIterator(itr).assertNumRowVectors(repeatTimes);
+  public static void assertIterator(ExportIterator itr, int repeatTimes) {
+    ExportIteratorTests.IteratorAssertionBuilder builder =
+        ExportIteratorTests.assertIterator(itr).assertNumRowVectors(repeatTimes);
     for (int i = 0; i < repeatTimes; i++) {
       builder =
           builder.assertRowVectorToString(


### PR DESCRIPTION
As title. Improve the iterator naming for less confusing.

This includes API breaking changes.